### PR TITLE
CI for vdsd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM jekyll/builder:3.8
 
-# RUN groupadd --gid 504 jenkins && useradd --uid 504 --gid jekyll
-
-RUN groupadd --gid 504 jenkins \
-  && usermod -a -G jenkins jekyll
+# add docker user 'jekyll' to the host jenkins group
+RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
 
 RUN npm config set unsafe-perm true && npm install -g s3-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM jekyll/builder:3.8
+
+# RUN groupadd --gid 504 jenkins && useradd --uid 504 --gid jekyll
+
+RUN groupadd --gid 504 jenkins \
+  && usermod -a -G jenkins jekyll
+
+RUN npm config set unsafe-perm true && npm install -g s3-cli
+
+WORKDIR /srv/jekyll

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
     stage('Build static site') {
       steps {
         sh 'npm run build'
-        sh 'jekyll build'
+        sh 'bundle exec jekyll build'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,52 @@
+pipeline {
+
+  agent {
+    //label 'vetsgov-general-purpose'
+    dockerfile true
+  }
+
+  // $HOME defaults to '/' when not set, which results in:
+  //   Error: EACCES: permission denied, mkdir '/.npm'
+  // jenkins runs docker using '-w <WORKSPACE>', so '.' points
+  // to that WORKSPACE
+  environment { HOME = '.' }
+
+  stages {
+    stage('Checkout Code') {
+      steps {
+        checkout scm
+      }
+    }
+
+    stage('Install npm dependencies') {
+      steps {
+        sh 'npm install'
+      }
+    }
+
+    stage('Build static site') {
+      steps {
+        sh 'bundle install && jekyll build'
+      }
+    }
+
+    stage('Tar assets and upload to S3') {
+      steps {
+        script {
+          ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+        }
+        echo "ref=${ref}"
+        echo "GIT_COMMIT={$GIT_COMMIT}"
+        sh 'tar -cf _site.tar.bz2 _site/'
+
+        withCredentials([[
+          $class:           'UsernamePasswordMultiBinding', 
+          credentialsId:    'vetsgov-website-builds-s3-upload',
+          usernameVariable: 'AWS_ACCESS_KEY', 
+          passwordVariable: 'AWS_SECRET_KEY']]) {
+          sh "s3-cli put --acl-public --region us-gov-west-1 _site.tar.bz2 s3://bucket-vagov-design-builds-s3-upload/bill_test_ev/bill_test_filename.tar.bz2"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webpack-dev-server": "^3.1.9"
   },
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "file:../veteran-facing-services-tools/packages/formation",
+    "@department-of-veterans-affairs/formation": "^5.3.0",
     "@department-of-veterans-affairs/formation-react": "^3.0.0",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0"
   },


### PR DESCRIPTION
Creates the CI needed.

Is based on an assumption that the build can be:

```
npm install
jekyll build
```

This also changes the npm dependency from being file-based to based on the [formation npm lib](https://www.npmjs.com/package/@department-of-veterans-affairs/formation)