### PR TITLE
Conform to BRD standard filenames

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
           credentialsId:    'vetsgov-website-builds-s3-upload',
           usernameVariable: 'AWS_ACCESS_KEY', 
           passwordVariable: 'AWS_SECRET_KEY']]) {
-          sh "s3-cli put --acl-public --region us-gov-west-1 _site.tar.bz2 s3://bucket-vagov-design-builds-s3-upload/$GIT_COMMIT/bill_test_filename.tar.bz2"
+          sh "s3-cli put --acl-public --region us-gov-west-1 _site.tar.bz2 s3://bucket-vagov-design-builds-s3-upload/$GIT_COMMIT/production.tar.bz2"
         }
       }
     }


### PR DESCRIPTION
The vets team follows a convention as part of it's build-release-deploy (BRD) infrastructure whereby artifacts uploaded to S3 have one of the following names:

- `production.tar.bz2`
- `staging.tar.bz2`
- `development.tar.bz2`

For now, I'm trying to get `production` BRD complete front to back. `staging` & `development` will come later.