### PR TITLE
change build path for gh_pages vs vets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ title: VA.gov Design System
 #email: your-email@example.com
 description: >- # this means to ignore newlines until "baseurl:"
   Design System for VA.gov
-baseurl: "/vets-design-system-documentation" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://design.va.gov" # the base hostname & protocol for your site, e.g. http://example.com
 
 project_name: VA.gov Design System

--- a/_config_gh_pages.yml
+++ b/_config_gh_pages.yml
@@ -1,0 +1,1 @@
+baseurl: "/vets-design-system-documentation" # the subpath of your site, e.g. /blog

--- a/deploy_site.sh
+++ b/deploy_site.sh
@@ -1,5 +1,5 @@
 rm -rf _site
-bundle exec jekyll build
+bundle exec jekyll build --config _config.yml,_config_gh_pages.yml # later configs override earlier ones
 cd _site
 git init
 git remote add origin git@github.com:department-of-veterans-affairs/vets-design-system-documentation.git


### PR DESCRIPTION
Deploying the current build 'as-is', to vets S3 bucket looks like this:
![image](https://user-images.githubusercontent.com/3077884/54767499-a29ea780-4bd3-11e9-8965-2c452eb11d07.png)

The path for the assets is rooted in `/vets-design-system-documentation`.

Work Done in This PR:
- change the `_config.yml` to have an empty `baseurl`
- create a separate `_config_gh_pages.yml` config that still has a `baseurl`:`/vets-design-system-documentation`
- updates the `deploy_site.sh` script to build with the new `_config_gh_pages.yml`