### PR TITLE
WiP - Make links pretty using :permalink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,26 +44,26 @@ sass:
 collections:
   documentation:
     output: true
-    permalink: /:collection/:title
+    permalink: /:collection/:title/
     label: Documentation
   content-style-guide:
     output: true
-    permalink: /:collection/:title
+    permalink: /:collection/:title/
   design:
     output: true
-    permalink: /:collection/:title
+    permalink: /:collection/:title/
   components:
     output: true
-    permalink: /:collection/:title
+    permalink: /:collection/:title/
   patterns:
     output: true
-    permalink: /:collection/:title
+    permalink: /:collection/:title/
   layout:
     output: true
-    permalink: /:collection/:title
+    permalink: /:collection/:title/
   utilities:
     output: true
-    permalink: /:collection/:title
+    permalink: /:collection/:title/
 
 
 includes:

--- a/src/_components/index.md
+++ b/src/_components/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Components
 index: true
+permalink: /:collection/index.html
 ---
 
 # Components

--- a/src/_content-style-guide/index.md
+++ b/src/_content-style-guide/index.md
@@ -2,6 +2,7 @@
 layout: default
 index: true
 title: VA.gov content style guide
+permalink: /:collection/index.html
 ---
 
 # VA.gov content style guide

--- a/src/_design/index.md
+++ b/src/_design/index.md
@@ -2,6 +2,7 @@
 layout: default
 index: true
 title: Design
+permalink: /:collection/index.html
 ---
 
 # Design

--- a/src/_documentation/index.md
+++ b/src/_documentation/index.md
@@ -2,6 +2,7 @@
 layout: default
 index: true
 title: Documentation
+permalink: /:collection/index.html
 ---
 
 # Getting started with design.va.gov

--- a/src/_documentation/whats-new.md
+++ b/src/_documentation/whats-new.md
@@ -96,7 +96,7 @@ Image paths in Formation are now relative, so the images and fonts folder are no
 ### March 13, 2019
 
 **Site updates**
-- Updates external [link icon documentation](../design/typography.html#links);
+- Updates external [link icon documentation](../../design/typography/index.html#links);
 
 ---
 

--- a/src/_layout/index.md
+++ b/src/_layout/index.md
@@ -2,6 +2,7 @@
 layout: default
 index: true
 title: Layout
+permalink: /:collection/index.html
 ---
 
 # Layout

--- a/src/_patterns/index.md
+++ b/src/_patterns/index.md
@@ -2,6 +2,7 @@
 layout: default
 index: true
 title: Patterns
+permalink: /:collection/index.html
 ---
 
 # Patterns

--- a/src/_utilities/index.md
+++ b/src/_utilities/index.md
@@ -2,6 +2,7 @@
 layout: default
 index: true
 title: Utilities
+permalink: /:collection/index.html
 ---
 
 # Utilities


### PR DESCRIPTION
### Background
When serving through jekyll or github pages, there's native support for "pretty links" (e.g. GET `/components/accordions` will point serve up `/components/accordions.html`). S3 website hosting does not have this feature. [The initial solution](https://github.com/department-of-veterans-affairs/devops/pull/4468) was for the deploy process to remove the .html extension from all files before uploading to S3, and then set the files' `content-type` metadata as `application/html`. Ultimately, this solution is turning out to be more complex than desired ([see new PR here](https://github.com/department-of-veterans-affairs/devops/pull/4521)). I'm exploring the use of `permalinks` as an alternate solution so that the `_site/` is in a more "ready-to-go" form without the need of file manipulation at deploy time.