### PR TITLE
full width alert documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,20 @@
       }
     },
     "@department-of-veterans-affairs/formation": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/formation/-/formation-6.2.3.tgz",
-      "integrity": "sha512-gcY+LqaIrgc31lvQ0Sn3kg7Yevq6joK1qnVFN2cpNeqosHRElSxrvDA+UjFBspBxW0mbXLTXME7iyZWfGtpwdw==",
+      "version": "file:../veteran-facing-services-tools/packages/formation",
       "requires": {
-        "@fortawesome/fontawesome-free": "5.7.2",
+        "@fortawesome/fontawesome-free": "5.8.1",
         "foundation-sites": "5.5.3"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-free": {
+          "version": "5.8.1",
+          "bundled": true
+        },
+        "foundation-sites": {
+          "version": "5.5.3",
+          "bundled": true
+        }
       }
     },
     "@department-of-veterans-affairs/formation-react": {
@@ -37,7 +45,8 @@
     "@fortawesome/fontawesome-free": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.7.2.tgz",
-      "integrity": "sha512-Ha4HshKdCVKgu4TVCtG8XyPPYdzTzNW4/fvPnn+LT7AosRABryhlRv4cc4+o84dgpvVJN9reN7jo/c+nYujFug=="
+      "integrity": "sha512-Ha4HshKdCVKgu4TVCtG8XyPPYdzTzNW4/fvPnn+LT7AosRABryhlRv4cc4+o84dgpvVJN9reN7jo/c+nYujFug==",
+      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -3310,11 +3319,6 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
-    },
-    "foundation-sites": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-5.5.3.tgz",
-      "integrity": "sha1-ZVbrKzHN47ImYwEWvSFdldBWwKc="
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "webpack-dev-server": "^3.1.9"
   },
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "6.2.3",
+    "@department-of-veterans-affairs/formation": "6.2.5",
     "@department-of-veterans-affairs/formation-react": "^3.0.0",
     "react": "^15.5.4",
     "react-addons-update": "^15.6.2",

--- a/src/_components/alertboxes.md
+++ b/src/_components/alertboxes.md
@@ -10,6 +10,7 @@ anchors:
   - anchor: Continue status
   - anchor: Alert boxes with expandable content
   - anchor: Background color only
+  - anchor: Full-width alerts
 ---
 
 # Alert boxes
@@ -30,6 +31,8 @@ Used to provide helpful information to a user or something that warrants attenti
 
 {% include snippet.html content='html/alert-informational.html' %}
 
+---
+
 ## Warning alert
 
 Used to warn a user, such as when there are negative consequences, but necessary when something has gone wrong.
@@ -39,6 +42,8 @@ Used to warn a user, such as when there are negative consequences, but necessary
 </div>
 
 {% include snippet.html content='html/alert-warning.html' %}
+
+---
 
 ## Success alert
 
@@ -50,6 +55,8 @@ Used to indicate success.
 
 {% include snippet.html content='html/alert-success.html' %}
 
+---
+
 ## Error alert
 
 Used when there is a problem or something destructive is about to occur.
@@ -59,6 +66,8 @@ Used when there is a problem or something destructive is about to occur.
 </div>
 
 {% include snippet.html content='html/alert-error.html' %}
+
+---
 
 ## Sign in or tool prompt
 
@@ -70,6 +79,8 @@ Used to prompt user to sign in, create an account, or launch a tool to access ce
 
 {% include snippet.html content='html/alert-continue.html' %}
 
+---
+
 ## Alert boxes with expandable content
 
 Any style of alert box may be made to include expandable content.
@@ -79,6 +90,8 @@ Any style of alert box may be made to include expandable content.
 </div>
 
 {% include snippet.html content='html/alert-expandable.html' %}
+
+---
 
 ## Background color only
 
@@ -90,11 +103,32 @@ Any style of alert box can be made to be background color only. Background color
 
 {% include snippet.html content='html/alert-background-color.html' %}
 
-### Guidance
-
 - Some users might not be able to distinguish differences in the background color, or see the color at all. Do not rely on color alone to convey context.
 - Messaging should be direct and concise. Aim for one or two lines.
 - Do not use headings
+
+---
+
+## Full-width alerts
+
+Full-width alerts can only appear below the main navigation and are used only for emergency or very urgent communications.
+
+<div class="site-c-showcase">
+{% include_relative html/alert-full-width.html %}
+</div>
+
+{% include snippet.html content='html/alert-full-width2.html' %}
+
+<div class="site-c-showcase">
+{% include_relative html/alert-full-width2.html %}
+</div>
+
+{% include snippet.html content='html/alert-full-width.html' %}
+
+- Only available in `info` or `warning` variants.
+- Use for emergency or very urgent communications only. Ex: hurricane alert; government shutdown affecting VA services, etc.
+- Do not stack - max is one per page at any one time. (If multiple emergency issues occur at once, make message content combined and link out to a landing page or to individual affected medical centers, for example.)
+- Can be used on homepage or, in true emergencies, on lower level pages.
 
 ---
 

--- a/src/_components/alertboxes.md
+++ b/src/_components/alertboxes.md
@@ -113,20 +113,25 @@ Any style of alert box can be made to be background color only. Background color
 
 Full-width alerts can only appear below the main navigation and are used only for emergency or very urgent communications.
 
+### Warning
 <div class="site-c-showcase">
 {% include_relative html/alert-full-width.html %}
 </div>
 
 {% include snippet.html content='html/alert-full-width2.html' %}
 
+### Informational
 <div class="site-c-showcase">
 {% include_relative html/alert-full-width2.html %}
 </div>
 
 {% include snippet.html content='html/alert-full-width.html' %}
 
+### More about full-width alerts
 - Only available in `info` or `warning` variants.
-- Use for emergency or very urgent communications only. Ex: hurricane alert; government shutdown affecting VA services, etc.
+- Content inside alert remains aligned the main page grid container. This might not be apparent on this site in smaller screens.
+- Use for emergency or very urgent communications only. Ex: hurricane alert; government shutdown affecting VA services, etc. Emergency homepage alerts notify Veterans, VA employees, and the public of events that affect VA services or site features.
+- To ensure that customers always know they can find critical service information in this area, do not use emergency homepage alerts for general press, outreach, or administrative messages.
 - Do not stack - max is one per page at any one time. (If multiple emergency issues occur at once, make message content combined and link out to a landing page or to individual affected medical centers, for example.)
 - Can be used on homepage or, in true emergencies, on lower level pages.
 

--- a/src/_components/html/alert-full-width.html
+++ b/src/_components/html/alert-full-width.html
@@ -3,14 +3,14 @@
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading" id="alert-heading">Alert heading</h3>
       <div class="usa-alert-text">
-        <p><strong>Some VA facilities and services are affected</strong></p>
+        <p><strong>Sample subheading</strong></p>
         <p>Sample alert showing different events at multiple facilities.</p>
         <ul>
           <li>VAMC Name in City, State, is affected by (natural disaster/event).</li>
           <li>VAMC Name in City, State, is affected by (natural disaster/event).</li>
         </ul>
-        <p><a href="#">See all affected services and facilities</a></p>
-        <p>Veteran’s Health Resource Center Disaster Hotline: [phone #]</p>
+        <p><a href="#">Sample link to additional material</a></p>
+        <p>Sample text for phone number: [phone #]</p>
       </div>
     </div>
   </div>

--- a/src/_components/html/alert-full-width.html
+++ b/src/_components/html/alert-full-width.html
@@ -1,0 +1,12 @@
+<div class="usa-alert-full-width usa-alert-full-width-warning" role="region" aria-labelledby="alert-heading">
+  <div class="usa-alert usa-alert-warning" aria-live="assertive" role="alert">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading" id="alert-heading">Alert heading</h3>
+      <div class="usa-alert-text">
+        <p>
+          Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/_components/html/alert-full-width.html
+++ b/src/_components/html/alert-full-width.html
@@ -3,9 +3,14 @@
     <div class="usa-alert-body">
       <h3 class="usa-alert-heading" id="alert-heading">Alert heading</h3>
       <div class="usa-alert-text">
-        <p>
-          Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.
-        </p>
+        <p><strong>Some VA facilities and services are affected</strong></p>
+        <p>Sample alert showing different events at multiple facilities.</p>
+        <ul>
+          <li>VAMC Name in City, State, is affected by (natural disaster/event).</li>
+          <li>VAMC Name in City, State, is affected by (natural disaster/event).</li>
+        </ul>
+        <p><a href="#">See all affected services and facilities</a></p>
+        <p>Veteran’s Health Resource Center Disaster Hotline: [phone #]</p>
       </div>
     </div>
   </div>

--- a/src/_components/html/alert-full-width2.html
+++ b/src/_components/html/alert-full-width2.html
@@ -4,7 +4,7 @@
       <h3 class="usa-alert-heading" id="alert-heading">Alert heading</h3>
       <div class="usa-alert-text">
         <p>
-          Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.
+          Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod. Curabitur et est at odio varius dictum sed id risus. Maecenas nec auctor orci. Cras arcu eros, blandit ac lobortis nec, bibendum non nisi. Integer ut faucibus sapien. Nullam vitae ex interdum, ultrices arcu at, eleifend massa. Nulla imperdiet magna eu justo ullamcorper, sed commodo mauris iaculis. 
         </p>
       </div>
     </div>

--- a/src/_components/html/alert-full-width2.html
+++ b/src/_components/html/alert-full-width2.html
@@ -1,0 +1,12 @@
+<div class="usa-alert-full-width usa-alert-full-width-info" role="region" aria-labelledby="alert-heading">
+  <div class="usa-alert usa-alert-info" aria-live="assertive" role="alert">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading" id="alert-heading">Alert heading</h3>
+      <div class="usa-alert-text">
+        <p>
+          Lorem ipsum dolor sit amet, <a href="javascript:void(0);">consectetur adipiscing</a> elit, sed do eiusmod.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
The full-width alerts are now in Formation. Here's some documentation for them. 
<img width="1173" alt="Screen Shot 2019-05-02 at 5 25 41 PM" src="https://user-images.githubusercontent.com/25435289/57108150-e53dbe80-6cff-11e9-899b-42e21dae2736.png">

One thing I want us to do is to stop calling these "banners," so I am not going to reference them as such. They are a variant on the alert component, so we should call them full-width alerts, as the code implies, but I'm open to "page-width alerts" too, as long as we call it some kind of alert - though I think we should name them as we do in the code so we all use the same language.  

Please review the usage in the screenshot or page. I think I referenced everything in the github issue.
