### PR TITLE
DRAFT page titles

### DIFF
--- a/src/_content-style-guide/page-titles-and-section-titles.md
+++ b/src/_content-style-guide/page-titles-and-section-titles.md
@@ -35,7 +35,7 @@ Section and subsection titles (also sometimes called headers and subheads) help 
 
 - Try to keep section and subsection titles to 70 characters maximum, with spaces. 
 
-We allow a little more character count for sections and subsections than page titles. But in general, sections become hard to scan when they're too long.  Eliminate unnecessary details or nuance in section and subsection titles, and address them with more depth in the paragraph copy.
+We allow a little more character count for sections and subsections than page titles. But in general, sections become hard to scan when they're too long. Eliminate unnecessary details or nuance in section and subsection titles, and address them with more depth in the paragraph copy.
 
 For more information about structuring sections using H2s and H3s, see [How to use headings](https://yoast.com/how-to-use-headings-on-your-site/) on Yoast.com.
 

--- a/src/_content-style-guide/page-titles-and-section-titles.md
+++ b/src/_content-style-guide/page-titles-and-section-titles.md
@@ -1,7 +1,66 @@
 ---
 layout: default
 title: Page titles and section titles
-draft: true
+anchors:
+ - anchor: Page titles
+ - anchor: Section titles
 ---
 
 # Page titles and section titles
+
+Page and section titles do a lot of heavy lifting. A good rule of thumb is to hide all the text on a page, except the page title, section titles, subsection titles, and the primary CTA. 
+
+If someone can still figure out what they need to do on that page or what that page is about, it's a good sign that the page and section titles are working well.  
+
+
+
+## Page titles 
+
+Page titles have a few important functions: 
+
+- To clearly and quickly tell people the main purpose of the page—what can they do or what information they can get on that page.
+- To [optimize the page for search](https://design.va.gov/content-style-guide/seo), so the information is findable through Google and other search engines. 
+
+Try to keep page titles to 60 characters maximum, with spaces. Use the primary SEO keyword in the page title. On VA.gov, page titles use the H1 tag.
+
+
+
+
+
+## Section titles
+
+Section and subsection titles (also sometimes called headers and subheads) help organize the page into scannable, user-friedly chunks. They should provide clear guide posts and bring people deeper into the content. 
+
+- Structure section titles with H2s and subsections with H3s, and so on. This provides a natural hierarchy for your content, and helps SEO.
+
+- Try to keep section and subsection titles to 70 characters maximum, with spaces. 
+
+We allow a little more character count for sections and subsections than page titles. But in general, sections become hard to scan when they're too long.  Eliminate unnecessary details or nuance in section and subsection titles, and address them with more depth in the paragraph copy.
+
+For more information about structuring sections using H2s and H3s, see [How to use headings](https://yoast.com/how-to-use-headings-on-your-site/) on Yoast.com.
+
+<div class="do-dont">
+<div class="do-dont__do">
+<h3 class="do-dont__heading">Like this</h3>
+<div class="do-dont__content" markdown="1">
+
+
+
+**H1 page title** How to apply for college
+
+- **H2** Documents you need before you start your college application
+- **H2** Ways to apply to colleges 
+
+> - H3 Apply online 
+
+> - H3 Apply by mail 
+
+- **H2** What happens after you apply
+
+> - H3 How long it takes to find out from colleges 
+
+- **H2** More information about applying for college 
+
+</div>
+</div>
+</div>

--- a/src/_content-style-guide/page-titles-and-section-titles.md
+++ b/src/_content-style-guide/page-titles-and-section-titles.md
@@ -21,7 +21,7 @@ Page titles have a few important functions:
 - To clearly and quickly tell people the main purpose of the page—what can they do or what information they can get on that page.
 - To [optimize the page for search](https://design.va.gov/content-style-guide/seo), so the information is findable through Google and other search engines. 
 
-Try to keep page titles to 60 characters maximum, with spaces. Use the primary SEO keyword in the page title. On VA.gov, page titles use the H1 tag.
+Try to keep page titles to 52 characters maximum, with spaces. Use the primary SEO keyword in the page title. On VA.gov, page titles use the H1 tag.
 
 
 

--- a/src/_content-style-guide/page-titles-and-section-titles.md
+++ b/src/_content-style-guide/page-titles-and-section-titles.md
@@ -29,7 +29,7 @@ Try to keep page titles to 52 characters maximum, with spaces. Use the primary S
 
 ## Section titles
 
-Section and subsection titles (also sometimes called headers and subheads) help organize the page into scannable, user-friedly chunks. They should provide clear guide posts and bring people deeper into the content. 
+Section and subsection titles (also sometimes called headers and subheads) help organize the page into scannable, user-friendly chunks. They should provide clear guideposts and bring people deeper into the content. 
 
 - Structure section titles with H2s and subsections with H3s, and so on. This provides a natural hierarchy for your content, and helps SEO.
 
@@ -57,7 +57,7 @@ For more information about structuring sections using H2s and H3s, see [How to u
 
 - **H2** What happens after you apply
 
-> - H3 How long it takes to find out from colleges 
+> - H3 How long it takes to hear back from colleges 
 
 - **H2** More information about applying for college 
 


### PR DESCRIPTION
@DanielleSoCompany @bethpotts CC @RLHecht  - I’m unhiding the style guide topic for “Page titles and section titles” in the content style guide site. Please take a look at this PR page and let me know if you see any issues. 

Right now, we don’t have any character count limit per se for page titles and section titles ( H1s and h2, h3 headers). We do have  a count for the whole meta browser title in the SEO meta guidelines however. 

@DanielleSoCompany  - If we work backward from the SEO guidelines, it would mean that the character limit for H1 page titles are 41 with spaces (because 60 is the max with | Veterans Affairs).  

I was looking around our pages and some of the page title H1s are more like 50-60 characters long.  

I don’t see a big problem with that length - 60 characters for page titles. I think even searches accommodate a little longer than our recommended 60 total for the meta title. 

Would you all be okay with allowing 60 characters for H1s -- and alternately,  revising the guidance for SEO to allow longer browser title?  If we allow 60 max for H1s, then, the max for meta browser tile would be 60 + space+ | Veterans Affairs - 79. 

