### PR TITLE
WiP - Migrate build to VAEC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
 
   agent {
     dockerfile {
-      label 'vetsgov-general-purpose'
+      label 'vagov-general-purpose'
     }
   }
 


### PR DESCRIPTION
This will use the new jenkins swarm nodes deployed to the new VAEC (VA enterprise cloud), a new VA AWS VPC, to build VDSD. 

Should not have any result on builds.