### PR TITLE
WIP - allow docker container to reach github ssl (SSL inappropriate fallback)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,6 @@ FROM jekyll/builder:3.8
 # add docker user 'jekyll' to the host jenkins group
 RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
 
-# allows ssl connections through TIC (npm downloads from github for example)
-COPY /va_certs/dod-eca.pem dod-eca.crt
-COPY /va_certs/VA-Internal-S2-ICA1-v1.pem.pem VA-Internal-S2-ICA1-v1.crt
-COPY /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt
-COPY /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt
-COPY /va_certs/va.pem va.crt
-
-ADD *.crt /usr/local/share/ca-certificates/
-RUN update-ca-certificates
-
-
 RUN npm config set unsafe-perm true && npm install -g s3-cli
 
 WORKDIR /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM jekyll/builder:3.8
 # add docker user 'jekyll' to the host jenkins group
 # RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
 
-# RUN npm config set unsafe-perm true && npm install -g s3-cli
-
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 ADD *.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
+
+RUN npm config set unsafe-perm true && npm install -g s3-cli
 
 WORKDIR /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,6 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 ADD *.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 
-RUN npm config get cafile
-
-RUN npm config set cafile /usr/local/share/ca-certificates/
-
 RUN npm config set unsafe-perm true && npm install -g s3-cli
 
 WORKDIR /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM jekyll/builder:3.8
 
 # RUN npm config set unsafe-perm true && npm install -g s3-cli
 
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 ADD *.crt /usr/local/share/ca-certificates/
-
 RUN update-ca-certificates
 
 WORKDIR /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ FROM jekyll/builder:3.8
 RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
 
 # allows ssl connections through TIC (npm downloads from github for example)
-COPY /etc/pki/ca-trust/source/anchors/dod-eca.pem dod-eca.crt
-COPY /etc/pki/ca-trust/source/anchors/VA-Internal-S2-ICA1-v1.pem.pem VA-Internal-S2-ICA1-v1.crt
-COPY /etc/pki/ca-trust/source/anchors/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt
-COPY /etc/pki/ca-trust/source/anchors/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt
-COPY /etc/pki/ca-trust/source/anchors/va.pem va.crt
+COPY /va_certs/dod-eca.pem dod-eca.crt
+COPY /va_certs/VA-Internal-S2-ICA1-v1.pem.pem VA-Internal-S2-ICA1-v1.crt
+COPY /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt
+COPY /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt
+COPY /va_certs/va.pem va.crt
 
 ADD *.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,17 @@ FROM jekyll/builder:3.8
 # add docker user 'jekyll' to the host jenkins group
 RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
 
+# allows ssl connections through TIC (npm downloads from github for example)
+COPY /etc/pki/ca-trust/source/anchors/dod-eca.pem dod-eca.crt
+COPY /etc/pki/ca-trust/source/anchors/VA-Internal-S2-ICA1-v1.pem.pem VA-Internal-S2-ICA1-v1.crt
+COPY /etc/pki/ca-trust/source/anchors/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt
+COPY /etc/pki/ca-trust/source/anchors/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt
+COPY /etc/pki/ca-trust/source/anchors/va.pem va.crt
+
+ADD *.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+
 RUN npm config set unsafe-perm true && npm install -g s3-cli
 
 WORKDIR /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 ADD *.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 
+RUN npm config get cafile
+
+RUN npm config set cafile /usr/local/share/ca-certificates/
+
 RUN npm config set unsafe-perm true && npm install -g s3-cli
 
 WORKDIR /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM jekyll/builder:3.8
 
 # add docker user 'jekyll' to the host jenkins group
-RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
+# RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
 
 RUN npm config set unsafe-perm true && npm install -g s3-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM jekyll/builder:3.8
 # add docker user 'jekyll' to the host jenkins group
 # RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
 
-RUN npm config set unsafe-perm true && npm install -g s3-cli
+# RUN npm config set unsafe-perm true && npm install -g s3-cli
+
+ADD *.crt /usr/local/share/ca-certificates/
+
+RUN update-ca-certificates
 
 WORKDIR /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM jekyll/builder:3.8
 # add docker user 'jekyll' to the host jenkins group
 # RUN groupadd --gid 504 jenkins && usermod -a -G jenkins jekyll
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk --no-cache add ca-certificates
 ADD *.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     stage('Install npm dependencies') {
       steps {
         script {
-          args = "-v ${pwd()}:/srv/jekyll"
+          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca"
           dockerImage.inside(args) {
             sh 'openssl s_client -showcerts -connect github.com:443'
             sh 'npm install'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     stage('Install npm dependencies') {
       steps {
         script {
-          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca"
+          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca -e HOME=/srv/jekyll"
           dockerImage.inside(args) {
             sh 'echo $HOME' 
             sh 'echo $NODE_OPTIONS' 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 pipeline {
 
   agent {
-    dockerfile {
+    // dockerfile {
       label 'vagov-general-purpose'
       // args '-v /etc/pki/ca-trust/source/anchors:/va_certs'
       // args '-u 504:1000'
-    }
+    // }
   }
 
   // $HOME defaults to '/' when not set, which results in:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,20 @@ pipeline {
   environment { HOME = '.' }
 
   stages {
+
+    stage('Update VA CA Certificates') {
+      steps {
+        sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
+        sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
+        sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
+        sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
+        sh 'cp /va_certs/va.pem va.crt'
+
+        sh 'cp *.crt /usr/local/share/ca-certificates/'
+        sh 'update-ca-certificates'
+      }
+    }
+
     stage('Checkout Code') {
       steps {
         checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,9 +50,8 @@ pipeline {
     stage('Install npm dependencies') {
       steps {
         script {
-          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca"
+          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca -e HOME=."
           dockerImage.inside(args) {
-            sh 'openssl s_client -showcerts -connect github.com:443'
             sh 'npm install'
             sh 'bundle install'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   agent {
     dockerfile {
       label 'vagov-general-purpose'
-      args '-v /etc/pki/ca-trust/source/anchors:/va_certs'
+      args '-v /etc/pki/ca-trust/source/anchors:/usr/local/share/ca-certificates'
     }
   }
 
@@ -28,7 +28,7 @@ pipeline {
         // sh 'cp /va_certs/va.pem va.crt'
 
         // sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
-        // sh 'update-ca-certificates'
+        sh 'update-ca-certificates'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     stage('Install npm dependencies') {
       steps {
         script {
-          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca -e HOME=."
+          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca -e HOME=/srv/jekyll"
           dockerImage.inside(args) {
             sh 'npm install'
             sh 'bundle install'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
   //   Error: EACCES: permission denied, mkdir '/.npm'
   // jenkins runs docker using '-w <WORKSPACE>', so '.' points
   // to that WORKSPACE
-  environment { HOME = '.' }
+  // environment { HOME = '.' }
 
   stages {
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
         script {
           args = "-v ${pwd()}:/srv/jekyll"
           dockerImage.inside(args) {
+            sh 'openssl s_client -showcerts -connect github.com:443'
             sh 'npm install'
             sh 'bundle install'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   agent {
     dockerfile {
       label 'vagov-general-purpose'
-      args '-v /etc/pki/ca-trust/source/anchors:/usr/local/share/ca-certificates'
+      args '-v /etc/pki/ca-trust/source/anchors:/va_certs'
     }
   }
 
@@ -21,13 +21,13 @@ pipeline {
         sh 'ls -l'
         sh 'whoami'
 
-        // sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
-        // sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
-        // sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
-        // sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
-        // sh 'cp /va_certs/va.pem va.crt'
+        sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
+        sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
+        sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
+        sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
+        sh 'cp /va_certs/va.pem va.crt'
 
-        // sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
+        sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
         sh 'update-ca-certificates'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,10 @@ pipeline {
 
     stage('Update VA CA Certificates') {
       steps {
+        sh 'pwd'
+        sh 'ls -l'
+        sh 'whoami'
+
         sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
         sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
         sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@ pipeline {
   agent {
     dockerfile {
       label 'vagov-general-purpose'
-      args '-v /etc/pki/ca-trust/source/anchors:/va_certs'
-      args '-u 504:1000'
+      // args '-v /etc/pki/ca-trust/source/anchors:/va_certs'
+      // args '-u 504:1000'
     }
   }
 
@@ -16,7 +16,7 @@ pipeline {
 
   stages {
 
-    stage('Update VA CA Certificates') {
+    stage('Copy the VA CA Certificates to the Docker Build Context') {
       steps {
         sh 'pwd'
         sh 'ls -l'
@@ -28,8 +28,8 @@ pipeline {
         sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
         sh 'cp /va_certs/va.pem va.crt'
 
-        sh 'cp *.crt /usr/local/share/ca-certificates/'
-        sh 'update-ca-certificates'
+        // sh 'cp *.crt /usr/local/share/ca-certificates/'
+        // sh 'update-ca-certificates'
       }
     }
 
@@ -39,56 +39,69 @@ pipeline {
       }
     }
 
-    stage('Install npm dependencies') {
-      steps {
-        sh 'npm install'
-        sh 'bundle install'
-      }
-    }
-
-    stage('Build static site') {
-      steps {
-        sh 'npm run build'
-        sh 'bundle exec jekyll build'
-      }
-    }
-
-    stage('Tar assets and upload to S3') {
-      when {
-        expression { env.BRANCH_NAME == 'master' }
-      }
-      steps {
-        sh 'tar -C _site -cf _site.tar.bz2 .'
-
-        withCredentials([[
-          $class:           'UsernamePasswordMultiBinding', 
-          credentialsId:    'vetsgov-website-builds-s3-upload',
-          usernameVariable: 'AWS_ACCESS_KEY', 
-          passwordVariable: 'AWS_SECRET_KEY']]) {
-          sh "s3-cli put --acl-public --region us-gov-west-1 _site.tar.bz2 s3://bucket-vagov-design-builds-s3-upload/$GIT_COMMIT/site.tar.bz2"
-        }
-      }
-    }
-
-    stage('Deploy dev & staging') {
-      when {
-        expression { env.BRANCH_NAME == 'master' }
-      }
+    stage('Build Docker Image') {
       steps {
         script {
-          commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+          dockerImage = docker.build() // builds the Dockerfile in current dir
         }
-
-        build job: 'deploys/vets-design-system-documentation-vagov-dev', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'ref', value: commit)
-        ], wait: false
-
-        build job: 'deploys/vets-design-system-documentation-vagov-staging', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'ref', value: commit)
-        ], wait: false
       }
     }
+
+    stage('Install npm dependencies') {
+      steps {
+        script {
+          args = "-v ${pwd()}:/srv/jekyll"
+          dockerImage.inside(args) {
+            sh 'npm install'
+            sh 'bundle install'
+          }
+        }
+      }
+    }
+
+    // stage('Build static site') {
+    //   steps {
+    //     sh 'npm run build'
+    //     sh 'bundle exec jekyll build'
+    //   }
+    // }
+
+    // stage('Tar assets and upload to S3') {
+    //   when {
+    //     expression { env.BRANCH_NAME == 'master' }
+    //   }
+    //   steps {
+    //     sh 'tar -C _site -cf _site.tar.bz2 .'
+
+    //     withCredentials([[
+    //       $class:           'UsernamePasswordMultiBinding', 
+    //       credentialsId:    'vetsgov-website-builds-s3-upload',
+    //       usernameVariable: 'AWS_ACCESS_KEY', 
+    //       passwordVariable: 'AWS_SECRET_KEY']]) {
+    //       sh "s3-cli put --acl-public --region us-gov-west-1 _site.tar.bz2 s3://bucket-vagov-design-builds-s3-upload/$GIT_COMMIT/site.tar.bz2"
+    //     }
+    //   }
+    // }
+
+    // stage('Deploy dev & staging') {
+    //   when {
+    //     expression { env.BRANCH_NAME == 'master' }
+    //   }
+    //   steps {
+    //     script {
+    //       commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+    //     }
+
+    //     build job: 'deploys/vets-design-system-documentation-vagov-dev', parameters: [
+    //       booleanParam(name: 'notify_slack', value: true),
+    //       stringParam(name: 'ref', value: commit)
+    //     ], wait: false
+
+    //     build job: 'deploys/vets-design-system-documentation-vagov-staging', parameters: [
+    //       booleanParam(name: 'notify_slack', value: true),
+    //       stringParam(name: 'ref', value: commit)
+    //     ], wait: false
+    //   }
+    // }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
     stage('Install npm dependencies') {
       steps {
         script {
-          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca -e HOME=/srv/jekyll"
+          args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca"
           dockerImage.inside(args) {
             sh 'echo $HOME' 
             sh 'echo $NODE_OPTIONS' 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     dockerfile {
       label 'vagov-general-purpose'
       args '-v /etc/pki/ca-trust/source/anchors:/va_certs'
+      args '-u 504:1000'
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
       steps {
         sh 'pwd'
         sh 'ls -l'
-        sh 'whoami'
+        // sh 'whoami'
 
         sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
         sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
@@ -27,7 +27,7 @@ pipeline {
         sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
         sh 'cp /va_certs/va.pem va.crt'
 
-        sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
+        sh 'cp *.crt /usr/local/share/ca-certificates/'
         sh 'update-ca-certificates'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
           dockerImage.inside(args) {
             sh 'echo $HOME' 
             sh 'echo $NODE_OPTIONS' 
-            sh 'npm install'
+            sh 'npm install --loglevel verbose'
             sh 'bundle install'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,22 +15,22 @@ pipeline {
 
   stages {
 
-    // stage('Update VA CA Certificates') {
-    //   steps {
-    //     sh 'pwd'
-    //     sh 'ls -l'
-    //     sh 'whoami'
+    stage('Update VA CA Certificates') {
+      steps {
+        sh 'pwd'
+        sh 'ls -l'
+        sh 'whoami'
 
-    //     sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
-    //     sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
-    //     sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
-    //     sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
-    //     sh 'cp /va_certs/va.pem va.crt'
+        // sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
+        // sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
+        // sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
+        // sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
+        // sh 'cp /va_certs/va.pem va.crt'
 
-    //     sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
-    //     sh 'update-ca-certificates'
-    //   }
-    // }
+        // sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
+        // sh 'update-ca-certificates'
+      }
+    }
 
     stage('Checkout Code') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
         sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
         sh 'cp /va_certs/va.pem va.crt'
 
-        sh 'cp *.crt /usr/local/share/ca-certificates/'
+        sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
         sh 'update-ca-certificates'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
     stage('Build Docker Image') {
       steps {
         script {
-          dockerImage = docker.build() // builds the Dockerfile in current dir
+          dockerImage = docker.build("bill-test:${env.BUILD_ID}") // builds the Dockerfile in current dir
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
   agent {
     dockerfile {
       label 'vetsgov-general-purpose'
+      args '-v /etc/pki/ca-trust/source/anchors:/va_certs'
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,8 @@ pipeline {
         script {
           args = "-v ${pwd()}:/srv/jekyll -e NODE_OPTIONS=--use-openssl-ca -e HOME=/srv/jekyll"
           dockerImage.inside(args) {
+            sh 'echo $HOME' 
+            sh 'echo $NODE_OPTIONS' 
             sh 'npm install'
             sh 'bundle install'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
 
   agent {
     dockerfile {
-      label 'vetsgov-general-purpose'
+      label 'vagov-general-purpose'
       args '-v /etc/pki/ca-trust/source/anchors:/va_certs'
     }
   }
@@ -15,22 +15,22 @@ pipeline {
 
   stages {
 
-    stage('Update VA CA Certificates') {
-      steps {
-        sh 'pwd'
-        sh 'ls -l'
-        sh 'whoami'
+    // stage('Update VA CA Certificates') {
+    //   steps {
+    //     sh 'pwd'
+    //     sh 'ls -l'
+    //     sh 'whoami'
 
-        sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
-        sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
-        sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
-        sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
-        sh 'cp /va_certs/va.pem va.crt'
+    //     sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
+    //     sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
+    //     sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
+    //     sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
+    //     sh 'cp /va_certs/va.pem va.crt'
 
-        sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
-        sh 'update-ca-certificates'
-      }
-    }
+    //     sh 'sudo cp *.crt /usr/local/share/ca-certificates/'
+    //     sh 'update-ca-certificates'
+    //   }
+    // }
 
     stage('Checkout Code') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,11 +22,11 @@ pipeline {
         sh 'ls -l'
         // sh 'whoami'
 
-        sh 'cp /va_certs/dod-eca.pem dod-eca.crt'
-        sh 'cp /va_certs/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
-        sh 'cp /va_certs/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
-        sh 'cp /va_certs/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
-        sh 'cp /va_certs/va.pem va.crt'
+        sh 'cp /etc/pki/ca-trust/source/anchors/dod-eca.pem dod-eca.crt'
+        sh 'cp /etc/pki/ca-trust/source/anchors/VA-Internal-S2-ICA1-v1.pem VA-Internal-S2-ICA1-v1.crt'
+        sh 'cp /etc/pki/ca-trust/source/anchors/VA-Internal-S2-ICA2-v1.pem VA-Internal-S2-ICA2-v1.crt'
+        sh 'cp /etc/pki/ca-trust/source/anchors/VA-Internal-S2-RCA-v1.pem VA-Internal-S2-RCA-v1.crt'
+        sh 'cp /etc/pki/ca-trust/source/anchors/va.pem va.crt'
 
         // sh 'cp *.crt /usr/local/share/ca-certificates/'
         // sh 'update-ca-certificates'


### PR DESCRIPTION
Problem ([source build](http://jenkins.vetsgov-internal/job/testing/job/vets-design-system-documentation/job/vaec-migration/2/console)):
```
Cannot download "https://github.com/sass/node-sass/releases/download/v4.12.0/linux_musl-x64-64_binding.node": 

write EPROTO 139989193935720:error:1425F175:SSL routines:ssl_choose_client_version:inappropriate fallback:ssl/statem/statem_lib.c:1944:
```

Copies the necessary VA certificates required for SSL communication through the TIC.