### PR TITLE
Fix link to Sketch file on home page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -92,7 +92,7 @@ homepage: true
         </a>
       </div>
       <div class="vads-l-col--12 medium-screen:vads-l-col--6 vads-u-padding--2">
-        <a href="https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Design/Design%20Resources/Pattern%20Library/VA-gov-Pattern-Library.sketch" class="site-resource-link">
+        <a href="https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Design/Design%20Resources/Pattern%20Library/VA-gov-Pattern-Library.sketch" class="site-resource-link">
           <img src="{{ site.baseurl }}/assets/img/sketch-logo.svg" alt="">
           <div class="vads-u-padding-left--2">
             <h3 class="vads-u-margin--0 vads-u-font-family--sans">Formation UI kit</h3>


### PR DESCRIPTION
The current link at the bottom to the Sketch file is broken, I've updated it with the correct URL.