### PR TITLE
Remove comma after state names

### DIFF
--- a/src/_content-style-guide/dates-and-numbers.md
+++ b/src/_content-style-guide/dates-and-numbers.md
@@ -135,12 +135,12 @@ In the examples below, we spell out the street names, and style the compass poin
   
 <p class="va-address-block">
 1600 Pennsylvania Avenue, NW <br/>
-Washington, DC, 20500 <br/>
+Washington, DC 20500 <br/>
 </p>
   
 <p class="va-address-block">
 123 E. 45th Street <br/>
-New York, NY, 67890 <br/>
+New York, NY 67890 <br/>
 </p>
   
 </div>
@@ -152,7 +152,7 @@ New York, NY, 67890 <br/>
   
 <p class="va-address-block">
 1600 Pennsylvania Ave. Northwest<br/>
-Washington, DC, 20500<br/>
+Washington, DC 20500<br/>
 </p>
 
 <p class="va-address-block">


### PR DESCRIPTION
@DanielleThierryUSDSVA or @bethpotts  Could you please review this PR and merge? We had commas after the state abbreviations in the Like this Not this boxes, which shouldn't be there.