### PR TITLE
Fix typo in benefit-applications.md

### DIFF
--- a/src/_patterns/benefit-applications.md
+++ b/src/_patterns/benefit-applications.md
@@ -62,7 +62,7 @@ The featured content component is used to present the user with the most commonl
 <div class="do-dont__dont">
 <h3 class="do-dont__heading">Don’t</h3>
 <div class="do-dont__content" markdown="1">
-<p>Use two or more featured components for multiple scenarios, because their can't be more than one that is the most common. Use other page elements for this purpose.</p>
+<p>Use two or more featured components for multiple scenarios, because there can't be more than one that is the most common. Use other page elements for this purpose.</p>
 ![eligibility_page_heirarchy](/images/featured-content-dont.png) 
 </div>
 </div>


### PR DESCRIPTION
I noticed a typo in this pattern in the design system docs:

![image](https://user-images.githubusercontent.com/2008881/96289476-fc2aac00-0f99-11eb-95a3-86661bc68c09.png)
