### PR TITLE
Circleci deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
-      - run: aws s3 sync _site s3://<< parameters.bucket >>
+      - run: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read
 
 # Orchestrate or schedule a set of jobs
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
 
     steps:
       - checkout
+      - aws-cli/setup
       - run: yarn install
         # If this works, think about adding it to the Gemfile
       - run: gem install bundler:1.16.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
       - image: cimg/ruby:2.7.2-node
     environment:
       AWS_DEFAULT_REGION: us-gov-west-1
+    parameters:
+      bucket:
+        type: string
 
     steps:
       - checkout
@@ -20,12 +23,13 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
-      - run: aws s3 sync _site s3://dev-design.va.gov
+      - run: aws s3 sync _site s3://<< parameters.bucket >>
 
 # Orchestrate or schedule a set of jobs
 workflows:
-   deploy:
+   deploy-dev:
     jobs:
       - build-deploy:
+          bucket: "dev-design.va.gov"
           context:
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,6 @@
 version: 2.1
 # Use a package of configuration called an orb.
 orbs:
-  # Declare a dependency on the welcome-orb
-  welcome: circleci/welcome-orb@0.4.1
   aws-cli: circleci/aws-cli@1.3.1
 
 jobs:
@@ -26,12 +24,7 @@ jobs:
 
 # Orchestrate or schedule a set of jobs
 workflows:
-  # Name the workflow "welcome"
-  welcome:
-    # Run the welcome/run job in its own container
-    jobs:
-      - welcome/run
-  deploy:
+   deploy:
     jobs:
       - build-deploy:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,15 @@ jobs:
 
 # Orchestrate or schedule a set of jobs
 workflows:
-   deploy-dev:
+  deploy-dev:
     jobs:
       - build-deploy:
           bucket: "dev-design.va.gov"
+          context:
+            - Platform
+  deploy-staging:
+    jobs:
+      - build-deploy:
+          bucket: "staging-design.va.gov"
           context:
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
-      - run: aws s3 ls
+      - run: aws s3 sync _site s3://dev-design.va.gov
 
 # Orchestrate or schedule a set of jobs
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,18 @@ version: 2.1
 orbs:
   # Declare a dependency on the welcome-orb
   welcome: circleci/welcome-orb@0.4.1
+
+jobs:
+  build-deploy:
+    docker:
+      - image: cimg/ruby-node
+    steps:
+      - checkout
+      - run: yarn install
+      - run: bundle install
+      - run: yarn build
+      - run: bundle exec jekyll build
+
 # Orchestrate or schedule a set of jobs
 workflows:
   # Name the workflow "welcome"
@@ -11,3 +23,6 @@ workflows:
     # Run the welcome/run job in its own container
     jobs:
       - welcome/run
+  deploy:
+    jobs:
+      - build-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - checkout
       - run: yarn install
+        # If this works, think about adding it to the Gemfile
+      - run: gem install bundler:1.16.6
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,17 @@ workflows:
     jobs:
       - build-deploy:
           bucket: "dev-design.va.gov"
+          filters:
+            branches:
+              only: master
           context:
             - Platform
   deploy-staging:
     jobs:
       - build-deploy:
           bucket: "staging-design.va.gov"
+          filters:
+            branches:
+              only: master
           context:
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 jobs:
   build-deploy:
     docker:
-      - image: cimg/ruby-node
+      - image: cimg/ruby:2.7.2-node
     steps:
       - checkout
       - run: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,15 @@ version: 2.1
 orbs:
   # Declare a dependency on the welcome-orb
   welcome: circleci/welcome-orb@0.4.1
+  aws-cli: circleci/aws-cli@1.3.1
 
 jobs:
   build-deploy:
     docker:
       - image: cimg/ruby:2.7.2-node
+    environment:
+      AWS_DEFAULT_REGION: us-gov-west-1
+
     steps:
       - checkout
       - run: yarn install
@@ -17,6 +21,7 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
+      - run: aws s3 ls
 
 # Orchestrate or schedule a set of jobs
 workflows:
@@ -27,4 +32,6 @@ workflows:
       - welcome/run
   deploy:
     jobs:
-      - build-deploy
+      - build-deploy:
+          context:
+            - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,18 +30,22 @@ workflows:
   deploy-dev:
     jobs:
       - build-deploy:
+          # Set the bucket parameter to be the dev bucket
           bucket: "dev-design.va.gov"
           filters:
             branches:
               only: master
           context:
+            # The Platform context has the environment variables for setting up the aws cli
             - Platform
   deploy-staging:
     jobs:
       - build-deploy:
+          # Set the bucket parameter to be the staging bucket
           bucket: "staging-design.va.gov"
           filters:
             branches:
               only: master
           context:
+            # The Platform context has the environment variables for setting up the aws cli
             - Platform

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,25 +50,5 @@ pipeline {
       }
     }
 
-    stage('Deploy dev & staging') {
-      when {
-        expression { env.BRANCH_NAME == 'master' }
-      }
-      steps {
-        script {
-          commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
-        }
-
-        build job: 'deploys/vets-design-system-documentation-vagov-dev', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'ref', value: commit)
-        ], wait: false
-
-        build job: 'deploys/vets-design-system-documentation-vagov-staging', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'ref', value: commit)
-        ], wait: false
-      }
-    }
   }
 }


### PR DESCRIPTION
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/15169

in order to keep the deploy from overwriting the storybook deploy that is happening from the `veteran-facing-services-tools` repo, we need to do this in Circle rather than Jenkins.

Once this is merged, I will delete the following YAML configs from the devops repo:

- `deploys/vets-design-system-documentation-vagov-dev.yml`
- `deploys/vets-design-system-documentation-vagov-staging.yml`


We will only deploy to dev and staging when a new commit gets merged into master:

![image](https://user-images.githubusercontent.com/2008881/100156676-26f00600-2e5e-11eb-8c3a-d5c601607dac.png)
