### PR TITLE
Deploy fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
+        # We are taking these extra steps due tosome differences between Jekyll and AWS S3.
+        # More context:
+        #   https://simpleit.rocks/ruby/jekyll/tutorials/having-pretty-urls-in-a-jekyll-website-hosted-in-amazon-s3/
       - run:
           name: Remove .html extension on non-index files
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,27 @@ jobs:
       - run: bundle exec jekyll build
       - run:
           name: Remove .html extension on non-index files
-          command: find _site/ -type f ! -iname 'index.html' -iname '*.html' -print0 | while read -d $'\0' f; do mv "$f" "${f%.html}"; done
+          command: |
+            find _site/ -type f ! -iname 'index.html' -iname '*.html' \
+            -print0 | while read -d $'\0' f; do mv "$f" "${f%.html}"; done
       - run:
           name: Sync extensionless html files with correct type
-          command: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*" --exclude "*.*" --content-type "text/html"
+          command: |
+            aws s3 sync _site s3://<< parameters.bucket >> \
+            --acl public-read \
+            --delete \
+            --exclude "storybook/*" \
+            --exclude "*.*" \
+            --content-type "text/html"
       - run:
           name: Sync remaning files
-          command: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*" --exclude "*" --include "*.*"
+          command: |
+            aws s3 sync _site s3://<< parameters.bucket >> \
+            --acl public-read \
+            --delete \
+            --exclude "storybook/*" \
+            --exclude "*" \
+            --include "*.*"
 
 # Orchestrate or schedule a set of jobs
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: find _site/ -type f ! -iname 'index.html' -iname '*.html' -print0 | while read -d $'\0' f; do mv "$f" "${f%.html}"; done
       - run:
           name: Sync extensionless html files with correct type
-          command: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*" --exclude "*.*" --content-type text/html
+          command: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*" --exclude "*.*" --content-type "text/html"
       - run:
           name: Sync remaning files
           command: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*" --exclude "*" --include "*.*"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
-      - run: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read
+      - run: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*"
 
 # Orchestrate or schedule a set of jobs
 workflows:
@@ -32,9 +32,9 @@ workflows:
       - build-deploy:
           # Set the bucket parameter to be the dev bucket
           bucket: "dev-design.va.gov"
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context:
             # The Platform context has the environment variables for setting up the aws cli
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
-        # We are taking these extra steps due tosome differences between Jekyll and AWS S3.
+        # We are taking these extra steps due to some differences between Jekyll and AWS S3.
         # More context:
         #   https://simpleit.rocks/ruby/jekyll/tutorials/having-pretty-urls-in-a-jekyll-website-hosted-in-amazon-s3/
       - run:
@@ -41,7 +41,7 @@ jobs:
             --exclude "*.*" \
             --content-type "text/html"
       - run:
-          name: Sync remaning files
+          name: Sync remaining files
           command: |
             aws s3 sync _site s3://<< parameters.bucket >> \
             --acl public-read \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,15 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
-      - run: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*"
+      - run:
+          name: Remove .html extension on non-index files
+          command: find _site/ -type f ! -iname 'index.html' -iname '*.html' -print0 | while read -d $'\0' f; do mv "$f" "${f%.html}"; done
+      - run:
+          name: Sync extensionless html files with correct type
+          command: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*" --exclude "*.*" --content-type text/html
+      - run:
+          name: Sync remaning files
+          command: aws s3 sync _site s3://<< parameters.bucket >> --acl public-read --delete --exclude "storybook/*" --exclude "*" --include "*.*"
 
 # Orchestrate or schedule a set of jobs
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ workflows:
       - build-deploy:
           # Set the bucket parameter to be the dev bucket
           bucket: "dev-design.va.gov"
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context:
             # The Platform context has the environment variables for setting up the aws cli
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,8 @@ jobs:
       - run: yarn build
       - run: bundle exec jekyll build
         # We are taking these extra steps due to some differences between Jekyll and AWS S3.
+        # To access a .html file served from S3, the URL needs to have the .html extension.
+        # We're removing the extension to make the URLs prettier.
         # More context:
         #   https://simpleit.rocks/ruby/jekyll/tutorials/having-pretty-urls-in-a-jekyll-website-hosted-in-amazon-s3/
       - run:


### PR DESCRIPTION
This fixes a recently noticed problem where we had `*.html` files from recent deploys, but older extensionless html files that were taking precedence in the browser.

Context: https://dsva.slack.com/archives/G01BJ3ESXL4/p1610037389032700?thread_ts=1610037383.032600&cid=G01BJ3ESXL4

Our solution is modeled after: https://simpleit.rocks/ruby/jekyll/tutorials/having-pretty-urls-in-a-jekyll-website-hosted-in-amazon-s3/