### PR TITLE
Revert "Add storybook link"

### DIFF
--- a/src/_components/index.md
+++ b/src/_components/index.md
@@ -4,15 +4,6 @@ title: Components
 index: true
 ---
 
-<div class="feature">
-  <h3>Come check out our <a href="{{ site.baseurl }}/storybook" class="vads-u-color--link-default vads-u-font-weight--bold vads-u-text-decoration--none">Storybook pilot</a>!</h3>
-  <p>We are eager to receive feedback from designers & developers on their opionions on Storybook. Here are some example questions:</p>
-  <ul>
-    <li>Can you find guidance on how to use a component?</li>
-    <li>Are you able to see how a component will appear in a mobile viewport?</li>
-  </ul>
-</div>
-
 # Components
 
 <div class="va-introtext" markdown="1">


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-design-system-documentation#354

This triggered a deploy which accidentally removed the thing we were linking to. Removing the link so we have more time to troubleshoot.