### PR TITLE
Make sure storybook doesn't get deleted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,9 @@ workflows:
       - build-deploy:
           # Set the bucket parameter to be the dev bucket
           bucket: "dev-design.va.gov"
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context:
             # The Platform context has the environment variables for setting up the aws cli
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
+      - run: cd _site/ && mkdir storybook
         # We are taking these extra steps due to some differences between Jekyll and AWS S3.
         # To access a .html file served from S3, the URL needs to have the .html extension.
         # We're removing the extension to make the URLs prettier.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,9 +59,9 @@ workflows:
       - build-deploy:
           # Set the bucket parameter to be the dev bucket
           bucket: "dev-design.va.gov"
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context:
             # The Platform context has the environment variables for setting up the aws cli
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,9 @@ jobs:
             aws s3 sync _site s3://<< parameters.bucket >> \
             --acl public-read \
             --delete \
+            --include "*.*"
             --exclude "storybook/*" \
             --exclude "*" \
-            --include "*.*"
 
 # Orchestrate or schedule a set of jobs
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,9 @@ jobs:
             aws s3 sync _site s3://<< parameters.bucket >> \
             --acl public-read \
             --delete \
+            --exclude "*" \
             --include "*.*"
             --exclude "storybook/*" \
-            --exclude "*" \
 
 # Orchestrate or schedule a set of jobs
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
       - run: bundle install
       - run: yarn build
       - run: bundle exec jekyll build
-      - run: cd _site/ && mkdir storybook
         # We are taking these extra steps due to some differences between Jekyll and AWS S3.
         # To access a .html file served from S3, the URL needs to have the .html extension.
         # We're removing the extension to make the URLs prettier.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             --acl public-read \
             --delete \
             --exclude "*" \
-            --include "*.*"
+            --include "*.*" \
             --exclude "storybook/*" \
 
 # Orchestrate or schedule a set of jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             --delete \
             --exclude "*" \
             --include "*.*" \
-            --exclude "storybook/*" \
+            --exclude "storybook/*"
 
 # Orchestrate or schedule a set of jobs
 workflows:


### PR DESCRIPTION
A [recent change to the deploy pipeline](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/369) introduced a bug which accidentally deleted the `/storybook` directory. This fixes it to prevent that from happening.