### PR TITLE
Remove hardcoded HTML extension from links

### DIFF
--- a/src/_data/display.yml
+++ b/src/_data/display.yml
@@ -6,6 +6,6 @@ display:
   - name: inline-block
     description: "Sets an element‘s display to inline-block, where it can be arranged beside other elements and height, width, margin, and padding are accepted."
   - name: flex
-    description: 'Sets an element‘s display to flex to behave as a flex container. For more related utilities, check out the <a href="flexbox.html">flexbox utilities</a>.'
+    description: 'Sets an element‘s display to flex to behave as a flex container. For more related utilities, check out the <a href="flexbox">flexbox utilities</a>.'
   - name: none
     description: "Sets an element‘s display to none, hiding it visually and from screen readers."

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -52,7 +52,7 @@
         <a href="{{ site.baseurl }}/documentation/code-and-design" class="usa-button vads-u-margin--0">Get code and design files</a>
         <div id="search-container" class="site-search-container">
           <i class="fas fa-search search-icon"></i>
-          <form action="/results.html" method="get" id="search-form" class="search-form">
+          <form action="/results" method="get" id="search-form" class="search-form">
           <input type="search" class="site-search-container__input" id="search-input" placeholder="Search..." aria-label="Search" name="query" autocomplete="off">
           </form>
           <ul id="results-container" class="site-search-results" role="listbox"></ul>
@@ -66,7 +66,7 @@
 
 <div id="mobile-search-container" class="site-search-container site-seach-container--mobile">
   <i class="fas fa-search search-icon search-icon--mobile"></i>
-  <form action="/results.html" method="get" id="mobile-search-form" class="search-form">
+  <form action="/results" method="get" id="mobile-search-form" class="search-form">
     <input type="search" class="site-search-container__input vads-u-max-width--none" id="mobile-search-input" placeholder="Search..." aria-label="Search" name="query" autocomplete="off">
   </form>
   <ul id="mobile-results-container" class="site-search-results site-search-results--mobile" role="listbox"></ul>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -48,8 +48,8 @@
         </em>
       </div>
       <div class="site-header__utility-links">
-        <a href="{{ site.baseurl }}/documentation/whats-new.html" class="usa-button site-button-inverse">What’s new?</a>
-        <a href="{{ site.baseurl }}/documentation/code-and-design.html" class="usa-button vads-u-margin--0">Get code and design files</a>
+        <a href="{{ site.baseurl }}/documentation/whats-new" class="usa-button site-button-inverse">What’s new?</a>
+        <a href="{{ site.baseurl }}/documentation/code-and-design" class="usa-button vads-u-margin--0">Get code and design files</a>
         <div id="search-container" class="site-search-container">
           <i class="fas fa-search search-icon"></i>
           <form action="/results.html" method="get" id="search-form" class="search-form">

--- a/src/index.html
+++ b/src/index.html
@@ -25,15 +25,15 @@ homepage: true
 
   <div class="vads-l-row vads-u-margin-x--neg2 vads-u-margin-y--4">
     <div class="site-section-highlight vads-l-col--12 medium-screen:vads-l-col--4 vads-u-padding-y--5 vads-u-padding-x--2">
-      <h3 class="vads-u-margin--0 vads-u-font-family--sans"><a href="{{ site.baseurl }}/content-style-guide/content-principles.html">Content principles</a></h3>
+      <h3 class="vads-u-margin--0 vads-u-font-family--sans"><a href="{{ site.baseurl }}/content-style-guide/content-principles">Content principles</a></h3>
       <p class="vads-u-margin-y--0p5">Our content principles guide the voice and tone of everything we write.</p>
     </div>
     <div class="site-section-highlight vads-l-col--12 medium-screen:vads-l-col--4 vads-u-padding-y--5 vads-u-padding-x--2">
-      <h3 class="vads-u-margin--0 vads-u-font-family--sans"><a href="{{ site.baseurl }}/content-style-guide/seo.html">Writing for SEO</a></h3>
+      <h3 class="vads-u-margin--0 vads-u-font-family--sans"><a href="{{ site.baseurl }}/content-style-guide/seo">Writing for SEO</a></h3>
       <p class="vads-u-margin-y--0p5">See basic SEO tips and best practices for making content findable in searches.</p>
     </div>
     <div class="site-section-highlight vads-l-col--12 medium-screen:vads-l-col--4 vads-u-padding-y--5 vads-u-padding-x--2">
-      <h3 class="vads-u-margin--0 vads-u-font-family--sans"><a href="{{ site.baseurl }}/content-style-guide/word-list.html">Word list</a></h3>
+      <h3 class="vads-u-margin--0 vads-u-font-family--sans"><a href="{{ site.baseurl }}/content-style-guide/word-list">Word list</a></h3>
       <p class="vads-u-margin-y--0p5">Use our in-house style for common words on VA.gov, so we can use words and labels consistently.</p>
     </div>
 


### PR DESCRIPTION
@mchelen-gov noticed a bug where a link was hardcoded to a page with an `html` extension, but the S3 bucket only has html files without an extension. This fixes that issue, but there are lots of other examples of this same thing happening.


## Testing

Double checked that the links worked locally

## Screenshots

After these changes, these are the only things that match my regex, and I _think_ they're ok:

![image](https://user-images.githubusercontent.com/2008881/105402604-793e7080-5bdc-11eb-8983-5fdba098a01c.png)


[Slack thread for additional context](https://dsva.slack.com/archives/CBU0KDSB1/p1611250163022100)

