### PR TITLE
Using iframes to Storybook for component documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run: gem install bundler:1.16.6
       - run: bundle install
       - run: yarn build
-      - run: bundle exec jekyll build
+      - run: JEKYLL_ENV=production bundle exec jekyll build
         # We are taking these extra steps due to some differences between Jekyll and AWS S3.
         # To access a .html file served from S3, the URL needs to have the .html extension.
         # We're removing the extension to make the URLs prettier.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
     parameters:
       bucket:
         type: string
+      envConfig:
+        type: string
 
     steps:
       - checkout
@@ -22,7 +24,7 @@ jobs:
       - run: gem install bundler:1.16.6
       - run: bundle install
       - run: yarn build
-      - run: JEKYLL_ENV=production bundle exec jekyll build
+      - run: bundle exec jekyll build --config _config.yml,<< parameters.envConfig >>
         # We are taking these extra steps due to some differences between Jekyll and AWS S3.
         # To access a .html file served from S3, the URL needs to have the .html extension.
         # We're removing the extension to make the URLs prettier.
@@ -59,6 +61,7 @@ workflows:
       - build-deploy:
           # Set the bucket parameter to be the dev bucket
           bucket: "dev-design.va.gov"
+          envConfig: "jekyll-configs/dev.yml"
           filters:
             branches:
               only: master
@@ -70,6 +73,7 @@ workflows:
       - build-deploy:
           # Set the bucket parameter to be the staging bucket
           bucket: "staging-design.va.gov"
+          envConfig: "jekyll-configs/staging.yml"
           filters:
             branches:
               only: master
@@ -81,6 +85,7 @@ workflows:
       - build-deploy:
           # Set the bucket parameter to be the prod bucket
           bucket: "design.va.gov"
+          envConfig: "jekyll-configs/prod.yml"
           filters:
             branches:
               only: master

--- a/_config.yml
+++ b/_config.yml
@@ -72,3 +72,7 @@ exclude:
   - node_modules
   - tmp_remote_assets
   - .sass-cache
+
+# Default for building locally. See configuration files in jekyll-configs/ for
+# environment overrides.
+storybook_path: "http://localhost:6006"

--- a/jekyll-configs/dev.yml
+++ b/jekyll-configs/dev.yml
@@ -1,0 +1,1 @@
+storybook_path: "/storybook"

--- a/jekyll-configs/prod.yml
+++ b/jekyll-configs/prod.yml
@@ -1,0 +1,1 @@
+storybook_path: "/storybook"

--- a/jekyll-configs/staging.yml
+++ b/jekyll-configs/staging.yml
@@ -1,0 +1,1 @@
+storybook_path: "/storybook"

--- a/src/_components/action-links.md
+++ b/src/_components/action-links.md
@@ -6,7 +6,7 @@ title: Action links
 
 # Action links
 
-{% include storybook-preview.html height=500 story="components-action-link--page" %}
+{% include storybook-preview.html height=560 story="components-action-link--page" %}
 
 ## Guidance
 

--- a/src/_components/action-links.md
+++ b/src/_components/action-links.md
@@ -6,9 +6,7 @@ title: Action links
 
 # Action links
 
-<iframe width="100%" height="1000" src="https://design.va.gov/storybook/iframe.html?id=components-action-link--page&viewMode=story"></iframe>
-
-[Interact with this component on Storybook](https://design.va.gov/storybook/?path=/docs/components-action-link--page)
+{% include storybook-preview.html height=500 story="components-action-link--page" %}
 
 ## Guidance
 

--- a/src/_components/action-links.md
+++ b/src/_components/action-links.md
@@ -6,7 +6,7 @@ title: Action links
 
 # Action links
 
-![action links]({{site.baseurl}}/images/action-links-updated.png) 
+<iframe width="100%" height="1000" src="https://design.va.gov/storybook/iframe.html?id=components-action-link--page&viewMode=story"></iframe>
 
 [Interact with this component on Storybook](https://design.va.gov/storybook/?path=/docs/components-action-link--page)
 

--- a/src/_components/back-to-top.md
+++ b/src/_components/back-to-top.md
@@ -6,7 +6,8 @@ title: Back to top
 # Back to top
 The Back to top component helps users quickly navigate back to the top of long pages of content.
 
-![Back to top component]({{site.baseurl}}/images/back-to-top.png)
+<!-- ![Back to top component]({{site.baseurl}}/images/back-to-top.png) -->
+{% include storybook-preview.html story="components-back-to-top--default" %}
 
 ## Accessibility
 Focus should properly set on the `body` tag when users click the  Back to top button. Users should be able to set focus on the first link or button from the top of the page after pressing TAB. 

--- a/src/_components/breadcrumbs.md
+++ b/src/_components/breadcrumbs.md
@@ -6,8 +6,4 @@ title: Breadcrumbs
 
 # Breadcrumbs
 
-<div class="site-showcase">
-{% include_relative html/breadcrumbs.html %}
-</div>
-
-{% include snippet.html content='html/breadcrumbs.html' react_component='https://design.va.gov/storybook/?path=/docs/components-breadcrumbs--default' %}
+{% include storybook-preview.html story="components-breadcrumbs--default" %}

--- a/src/_includes/storybook-preview.html
+++ b/src/_includes/storybook-preview.html
@@ -1,0 +1,16 @@
+{% comment %}
+  Assume Storybook is running on the default port 6006.
+  `npm run start` will use the default JEKYLL_ENV=development.
+{% endcomment %}
+
+{% if jekyll.environment == "development" %}
+  {% assign storybook_path = "http://localhost:6006" %}
+{% else %}
+  {% assign storybook_path = "/storybook" %}
+{% endif %}
+
+<div class="site-showcase">
+  <iframe width="100%" height="{{ include.height }}" src="{{ storybook_path }}/iframe.html?id={{ include.story }}&viewMode=story"></iframe>
+</div>
+
+[See this in Storybook]({{ storybook_path }}/?path=/docs/{{ include.story }})

--- a/src/_includes/storybook-preview.html
+++ b/src/_includes/storybook-preview.html
@@ -1,16 +1,5 @@
-{% comment %}
-  Assume Storybook is running on the default port 6006.
-  `npm run start` will use the default JEKYLL_ENV=development.
-{% endcomment %}
-
-{% if jekyll.environment == "development" %}
-  {% assign storybook_path = "http://localhost:6006" %}
-{% else %}
-  {% assign storybook_path = "/storybook" %}
-{% endif %}
-
 <div class="site-showcase">
-  <iframe width="100%" height="{{ include.height }}" src="{{ storybook_path }}/iframe.html?id={{ include.story }}&viewMode=story"></iframe>
+  <iframe width="100%" height="{{ include.height }}" src="{{ site.storybook_path }}/iframe.html?id={{ include.story }}&viewMode=story"></iframe>
 </div>
 
-[See this in Storybook]({{ storybook_path }}/?path=/docs/{{ include.story }})
+[See this in Storybook]({{ site.storybook_path }}/?path=/docs/{{ include.story }})


### PR DESCRIPTION
Like it says on the tin, this PR is a proof-of-concept for using iframes pointing to Storybook stories. They'll look like this:
![image](https://user-images.githubusercontent.com/12970166/115093306-b90caf80-9ece-11eb-98f9-8ce9ef0d0751.png)

Usage is pretty straightforward:
```
{% include storybook-preview.html story="components-back-to-top--default" %}
```
We can even include an optional `height` parameter in the `include` statement if desired.