### PR TITLE
Fix the mobile nav for experimental design

### DIFF
--- a/src/_experimental-design/index.md
+++ b/src/_experimental-design/index.md
@@ -9,4 +9,4 @@ draft: true
 
 <div class="va-introtext">
 Welcome to the Experimental Design section. This is where the experiments in the design system that are have not been formally approved for use by all teams will live. 
-</div>.
+</div>

--- a/src/_includes/_mobile-nav.html
+++ b/src/_includes/_mobile-nav.html
@@ -172,11 +172,11 @@
 
     <!-- Use the accurate heading level to maintain the document outline -->
     <p class="usa-accordion usa-accordion-heading site-mobile-nav__accordion-heading">
-      <button class="usa-accordion-button site-mobile-nav__accordion-button" aria-expanded="{% if page.url contains "/experimental-design/" %}true{% else %}false{% endif %}" aria-controls="nav-a7">
+      <button class="usa-accordion-button site-mobile-nav__accordion-button" aria-expanded="{% if page.url contains "/experimental-design/" %}true{% else %}false{% endif %}" aria-controls="nav-a8">
         Experimental Design
       </button>
     </p>
-    <div id="nav-a7" class="usa-accordion-content site-mobile-nav__accordion-content" aria-hidden="{% if page.url contains "/exerimental-design/" %}false{% else %}true{% endif %}">
+    <div id="nav-a8" class="usa-accordion-content site-mobile-nav__accordion-content" aria-hidden="{% if page.url contains "/exerimental-design/" %}false{% else %}true{% endif %}">
       <ul class="site-mobile-nav-list">
         <li class="site-mobile-nav-list__item">
           <a class="site-mobile-nav-list__link {% if page.url contains "layout/index" %} current {% endif %}" href="{{ site.baseurl }}/experimental-design">Overview</a>

--- a/src/_includes/_mobile-nav.html
+++ b/src/_includes/_mobile-nav.html
@@ -179,10 +179,10 @@
     <div id="nav-a8" class="usa-accordion-content site-mobile-nav__accordion-content" aria-hidden="{% if page.url contains "/exerimental-design/" %}false{% else %}true{% endif %}">
       <ul class="site-mobile-nav-list">
         <li class="site-mobile-nav-list__item">
-          <a class="site-mobile-nav-list__link {% if page.url contains "layout/index" %} current {% endif %}" href="{{ site.baseurl }}/experimental-design">Overview</a>
+          <a class="site-mobile-nav-list__link {% if page.url contains "experimental-design/index" %} current {% endif %}" href="{{ site.baseurl }}/experimental-design">Overview</a>
         </li>
         {% for p in site.experimental-design %}
-            {% if p.experimental-design == "default" %}
+            {% if p.layout == "default" %}
             {% unless p.index or p.draft %}
               <li class="site-mobile-nav-list__item">
                 <a class="site-mobile-nav-list__link {% if p.url == page.url %} current {% endif %}" href="{{site.baseurl}}{{ p.url }}">{{p.title}}</a>


### PR DESCRIPTION
Shawna [discovered a bug](https://dsva.slack.com/archives/C01Q9PDPLE9/p1619144454045100) in the mobile nav for the experimental design section. There was some copy pasta that needed to be re-jiggered.
![image](https://user-images.githubusercontent.com/12970166/115914921-6d568a80-a427-11eb-9c7f-6bafd4974b31.png)
