### PR TITLE
Fixing 3:2 image example (was showing 1:1 example)

### DIFF
--- a/src/_design/image-aspect-ratios.md
+++ b/src/_design/image-aspect-ratios.md
@@ -42,7 +42,7 @@ Aspect ratios for images used on VA.gov
 
     <div class="vads-l-col vads-l-row site-showcase__col vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
       <div class="vads-l-col--12 medium-screen:vads-l-col--3">
-        <div class="site-aspect-ratio site-aspect-ratio--11"></div>
+        <div class="site-aspect-ratio site-aspect-ratio--32"></div>
       </div>
       <div class="vads-l-col--12 medium-screen:vads-l-col--1 medium-screen:vads-u-padding-left--2">
         <span class="site-utility-value">3:2</span>


### PR DESCRIPTION
Before

![Image_aspect_ratios_-_VA_gov_Design_System](https://user-images.githubusercontent.com/643678/116886797-86b1c080-abf7-11eb-8f7a-fd2ce09f0f9e.png)


After

![Image_aspect_ratios_-_VA_gov_Design_System](https://user-images.githubusercontent.com/643678/116886871-9f21db00-abf7-11eb-8395-cb69129c1ff6.png)
