### PR TITLE
Remove the edit link from the content style guide pages

### DIFF
--- a/src/_includes/edit-on-github.html
+++ b/src/_includes/edit-on-github.html
@@ -1,4 +1,6 @@
+{% if page.collection != "content-style-guide" %}
 <div class="vads-u-margin-top--7 vads-u-margin-bottom--neg8">
   <a href="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/edit/master/src/{{page.path}}" target="_blank">Edit this page in GitHub</a>
   (Permissions required)
 </div>
+{% endif %}


### PR DESCRIPTION
Per @rtwell's decision, this PR removes the edit link from the pages in the content style guide section of design.va.gov, but keeps it on the other pages.

## Screenshots
Link removed from the content style guide pages:
![image](https://user-images.githubusercontent.com/12970166/116945872-90561b00-ac2d-11eb-9f4e-04bb3ec69cc0.png)

Link kept for other pages:
![image](https://user-images.githubusercontent.com/12970166/116945972-cc897b80-ac2d-11eb-9c54-43001689713c.png)
