### PR TITLE
Remove the header font family override

### DIFF
--- a/src/assets/stylesheets/_components/_showcase.scss
+++ b/src/assets/stylesheets/_components/_showcase.scss
@@ -6,12 +6,6 @@
   padding: $units-2;
 }
 
-.site-showcase > h2,
-.site-showcase > h3,
-.site-showcase > h4 {
-  font-family: $font-sans;
-}
-
 .site-showcase + .highlighter-rouge {
   margin-top: -1px;
 }


### PR DESCRIPTION
Why were they even there in the first place? :confused:

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/267

**Note:** This doesn't update the actual headers on design.va.gov. They're still using Source Sans Pro. I don't know what the history of that is. :man_shrugging: 

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/117073008-31081180-ace6-11eb-9b13-fe7b83e06d6e.png)
**Note:** The H6 is still using Source Sans Pro, but that's how it is on va.gov as well. :man_shrugging: 