### PR TITLE
Update page-titles-and-section-titles.md

### DIFF
--- a/src/_content-style-guide/page-titles-and-section-titles.md
+++ b/src/_content-style-guide/page-titles-and-section-titles.md
@@ -23,6 +23,10 @@ Page titles have a few important functions:
 
 Try to keep page titles to 52 characters maximum, with spaces. Use the primary SEO keyword in the page title. On VA.gov, page titles use the H1 tag.
 
+**Exceptions:**
+
+- Articles in resources and support, the character limit for the page title is 70. 
+- News releases, blog titles, community stories, and local event titles don't have a page title character limit. 
 
 
 


### PR DESCRIPTION
Added exception page title character count info re RS articles, news releases, event titles, and community stories (used on VAMC sites and Outreach - but didn't specify because there will be other products that use news releases and so on next year when more tier 3 and OPIA sites get added).