### PR TITLE
Add timestamps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "minima", "~> 2.0"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-last-modified-at"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,9 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.11.0)
       jekyll (~> 3.3)
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.5.0)
@@ -48,6 +51,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.15)
     public_suffix (3.0.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -67,6 +71,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8.4)
   jekyll-feed (~> 0.6)
+  jekyll-last-modified-at
   minima (~> 2.0)
   tzinfo-data
 

--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,8 @@ sketch_github_link: https://github.com/department-of-veterans-affairs/vets.gov-t
 markdown: kramdown
 highlighter: rouge
 # theme: minima
-# plugins:
+plugins:
+  - jekyll-last-modified-at
 #  - jekyll-feed
 
 

--- a/src/_includes/edit-on-github.html
+++ b/src/_includes/edit-on-github.html
@@ -1,5 +1,5 @@
 {% if page.collection != "content-style-guide" %}
-<div class="vads-u-margin-top--7 vads-u-margin-bottom--neg8">
+<div class="vads-u-margin-top--7">
   <a href="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/edit/master/src/{{page.path}}" target="_blank">Edit this page in GitHub</a>
   (Permissions required)
 </div>

--- a/src/_includes/timestamps.html
+++ b/src/_includes/timestamps.html
@@ -3,7 +3,4 @@
 <div>Date added: {{ page.date_added | date: '%b %d, %Y' }}</div>
 {% endif %}
 
-{% if page.last_updated != null %}
-<!-- <div>Last updated: {{ page.date | date: '%b %d, %Y at %H:%M:%S %Z' }} -->
-<div>Last updated: {{ page.last_updated | date: '%b %d, %Y' }}</div>
-{% endif %}
+<div>Last updated: {{ page.last_modified_at | date: '%b %d, %Y' }}</div>

--- a/src/_includes/timestamps.html
+++ b/src/_includes/timestamps.html
@@ -1,0 +1,9 @@
+{% if page.date_added != null %}
+<!-- <div>Last updated: {{ page.date | date: '%b %d, %Y at %H:%M:%S %Z' }} -->
+<div>Date added: {{ page.date_added | date: '%b %d, %Y' }}</div>
+{% endif %}
+
+{% if page.last_updated != null %}
+<!-- <div>Last updated: {{ page.date | date: '%b %d, %Y at %H:%M:%S %Z' }} -->
+<div>Last updated: {{ page.last_updated | date: '%b %d, %Y' }}</div>
+{% endif %}

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -105,6 +105,7 @@
           {{ content }}
         </main>
         {% include edit-on-github.html %}
+        {% include timestamps.html %}
       </div>
       {% endif %}
 

--- a/src/assets/stylesheets/_layout/_site-content.scss
+++ b/src/assets/stylesheets/_layout/_site-content.scss
@@ -24,12 +24,12 @@
 .site-content__content {
   flex-basis: 100%;
   max-width: 100%;
-  padding: $units-3;
+  padding: $units-3 $units-3 0 $units-3;
 
   @include media($nav-width) {
     flex-basis: 75%;
     max-width: 75%;
-    padding: $units-8;
+    padding: $units-8 $units-8 0 $units-8;
   }
 }
 


### PR DESCRIPTION
# Description
Optionally adds timestamps to the bottom of the page. They only appear if the `date_added` or `last_updated` frontmatter appear on the page. This is intended for use in the experimental design section to keep track of when an experiment was added.

Ideally, these timestamps are updated automatically, but that was more work to figure out. :man_shrugging: This is the quick and dirty way to get _some_ information out there.

# Screenshots 
![image](https://user-images.githubusercontent.com/12970166/126858623-92460eba-d663-420d-a318-e99e1623c6f2.png)

![image](https://user-images.githubusercontent.com/12970166/126858611-64514d96-da95-4452-a1ef-ffb228a372e4.png)
