### PR TITLE
Remove debt team's alert code

### DIFF
--- a/src/_experimental-design/expandable-alert.md
+++ b/src/_experimental-design/expandable-alert.md
@@ -22,8 +22,6 @@ Mobile friendly expandable alerts combine the Additional Info component within B
 
 ### Code reference:
 
-[Debt team's expandable alert code](https://github.com/department-of-veterans-affairs/vets-website/blob/3476c57cd753cd9a8da7d466fb23cb892e1ce1c2/src/applications/medical-copays/components/StatusAlert.jsx) - this is an iteration of the original Vet Center code below, and has been reviewed by Robin and Josh.
-
 [Vet Center expandable alert code](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/static-pages/shared/ExpandableOperatingStatus.jsx)
 
 ### Accessibility requirements:


### PR DESCRIPTION
Removing the link to the debt team's alert code since the alert is being removed from the application