### PR TITLE
Clarify "On this page" usage

### DIFF
--- a/src/_components/on-this-page-jump-links.md
+++ b/src/_components/on-this-page-jump-links.md
@@ -9,7 +9,7 @@ anchors:
 
 # On this page jump link
 
-The On this page jump link component summarizes the sections (h2s) at the top of long pages and allows users to jump down the page to the respective section.
+The On this page jump link component summarizes the sections (`<h2>`s) at the top of long pages and allows users to jump down the page to the respective section.
 
 {% include storybook-preview.html height="250px" story="components-va-on-this-page--default" %}
 
@@ -25,7 +25,7 @@ This component is especially helpful for pages with a lot of content, as it help
 
 ### How to use the On this page jump link component
 - **Keep the first link and its corresponding heading close together,** so users can more easily make the connection that the links correspond to the H2 section titles
-- **The content on the page should have a minimum of two H2 section titles to use the On this page jump link.** 
+- **The content on the page must have a minimum of two H2 section titles to use the On this page jump link.** 
 - **On this page component pairs well with the Back to top component.** The [Back to top component](https://design.va.gov/components/back-to-top) helps users quickly navigate back to the top of long pages of content.
 
 ## Accessibility considerations


### PR DESCRIPTION
Be more specific about when the component should be used. This is after a discussion with @rtwell and @cvalarida 

The goal here is to avoid incidents where "On this page" is used on pages which don't have `<h2>` elements, leading to unexpected behavior.