### PR TITLE
29551: Update error message placement for <Checkbox /> component

### DIFF
--- a/src/_patterns/form-feedback.md
+++ b/src/_patterns/form-feedback.md
@@ -81,10 +81,6 @@ Error messages are generally the same. The error message is slightly different i
 
 ### Errors on checkboxes
 
-Unlike other form elements, error messages for checkboxes appear below
-
-#### Error message below checkbox
-
 <div class="site-showcase">
 {% include_relative html/error-checkbox.html %}
 </div>

--- a/src/_patterns/html/error-checkbox.html
+++ b/src/_patterns/html/error-checkbox.html
@@ -1,19 +1,18 @@
 <div class="form-checkbox usa-input-error">
-  <input type="checkbox" autocomplete="false" aria-describedby="checkbox-140-error-message" id="checkbox-140" />
-  <label class="usa-input-error-label" name="undefined-label" for="checkbox-140">Checkbox 1
-  </label>
-  <span class="usa-input-error-message" role="alert" id="checkbox-140-error-message">
-    <span class="sr-only">Error</span>
+  <span class="usa-input-error-message" role="alert" id="errorable-checkbox-5-error-message">
+    <span class="sr-only">Error</span> 
     Error message
   </span>
+  <input aria-describedby="errorable-checkbox-5-error-message" id="errorable-checkbox-5" type="checkbox">
+  <label class="usa-input-error-label" name="undefined-label" for="errorable-checkbox-5">Checkbox 1</label>
 </div>
 
 <div class="form-checkbox usa-input-error">
-  <span class="label-above-checkbox">If you don’t find your school in the search results, then check the box to enter in your school information manually.</span>
-  <input type="checkbox" autocomplete="false" aria-describedby="checkbox-141-error-message" id="checkbox-141" />
-  <label class="usa-input-error-label" name="undefined-label" for="checkbox-141">Checkbox 2</label>
-  <span class="usa-input-error-message" role="alert" id="checkbox-141-error-message">
-    <span class="sr-only">Error</span>
+  <span class="label-above-checkbox">If you don't find your school in the search results, then check the box to enter in your school information manually.</span>
+  <span class="usa-input-error-message" role="alert" id="errorable-checkbox-5-error-message">
+    <span class="sr-only">Error</span> 
     Error message
   </span>
+  <input aria-describedby="errorable-checkbox-5-error-message" id="errorable-checkbox-5" type="checkbox">
+  <label class="usa-input-error-label" name="undefined-label" for="errorable-checkbox-5">Checkbox 2</label>
 </div>


### PR DESCRIPTION
This PR moves the error message for the `<Checkbox/>` component in `src/_patterns/html/error-checkbox.html` to be located above the checkbox input rather than below it. Refer to this issue for details https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/535