### PR TITLE
Try to have codespaces use prod for storybook

### DIFF
--- a/jekyll-configs/codespace.yml
+++ b/jekyll-configs/codespace.yml
@@ -1,0 +1,1 @@
+storybook_path: "http://design.va.gov/storybook"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack && gulp build",
-    "start": "npm run build && bundle exec jekyll serve --baseurl ''"
+    "start": "npm run build && bundle exec jekyll serve --baseurl ''",
+    "start:codespace": "npm run build && bundle exec jekyll serve --baseurl '' --config _config.yml jekyll-configs/codespace.yml"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack && gulp build",
     "start": "npm run build && bundle exec jekyll serve --baseurl ''",
-    "start:codespace": "npm run build && bundle exec jekyll serve --baseurl '' --config _config.yml jekyll-configs/codespace.yml"
+    "start:codespace": "npm run build && bundle exec jekyll serve --baseurl '' --config _config.yml,jekyll-configs/codespace.yml"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
~This should allow non-engineers to have the storybook iframe work when running a preview in a codespace.~

It turns out that this won't work like I had hoped due to browser protections, but the white screen may be better than an error talking about `localhost:6006`

## Before

![image](https://user-images.githubusercontent.com/2008881/139483456-fc63e545-e72a-48cf-8946-a7031908ed02.png)


## After
![image](https://user-images.githubusercontent.com/2008881/139482565-c8a04b92-dba0-44e3-a0de-38d8b5258290.png)
