### PR TITLE
Update content-presentation.md

### DIFF
--- a/src/_patterns/content-presentation.md
+++ b/src/_patterns/content-presentation.md
@@ -2,23 +2,20 @@
 layout: default
 title: Content presentation
 anchors:
-  - anchor: Information callouts
+  - anchor: Featured content
   - anchor: Expandable content
 ---
 
 # Content presentation
 
 
-## Information callouts
+## Featured content
 
-Information callouts are light blue boxes that call attention to important information.
+[Featured content](https://design.va.gov/components/featured-content) components are light blue boxes that call attention to important information.
 
 <div class="site-showcase">
-{% include_relative html/information-callout.html %}
+{% include storybook-preview.html height="250px" story="components-featured-content--default-story" %}
 </div>
-
-{% include snippet.html content='html/information-callout.html' %}
-
 
 ## Expandable content
 


### PR DESCRIPTION
Switched out any mention of "information callouts" to say "Featured content" so we are citing an actual Design System component and the actual name that the CMS uses for these light blue boxes. Updated Storybook preview to point to Featured content web component.