### PR TITLE
Use correct loading indicator story

### DIFF
--- a/src/_components/loading-indicators.md
+++ b/src/_components/loading-indicators.md
@@ -6,4 +6,4 @@ title: Loading indicators
 
 # Loading indicators
 
-{% include storybook-preview.html story="components-loadingindicator--default" %}
+{% include storybook-preview.html height="150px" story="components-va-loading-indicator--default" %}


### PR DESCRIPTION
Point the loading indicator documentation to the story for the newly released Web Component

![image](https://user-images.githubusercontent.com/2008881/142946507-683e9a2c-9986-4980-8618-7a499f1c104b.png)
