### PR TITLE
Update for-designers.md

### DIFF
--- a/src/_documentation/for-designers.md
+++ b/src/_documentation/for-designers.md
@@ -31,6 +31,10 @@ Before getting started, we recommend that you get familiar with the VA.gov Desig
 
 The website displays HTML and CSS examples of the various components and patterns in use on VA.gov. You can use your browser’s web inspector to view the specs for each component. If you use Sketch, each of the components has been added to a VA pattern library as well.
 
+<ul class="usa-unstyled-list">
+  <li><a href="{{ site.baseurl }}/downloads/VA-gov-Pattern-Library_120721.sketch"><span class="fa fa-download vads-u-display--inline-block vads-u-margin-right--1"></span>Download the Sketch VA Pattern Library</a></li>
+</ul>
+
 ## Sketch for Teams at VA
 
 Design teams at VA use Sketch for Teams to view, share, and collaborate on our work. Only designers actively working on products at VA.gov can be added to Sketch for Teams. Once you have been added, you may access the [VA pattern library](https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156) in the cloud or via download.

--- a/src/_documentation/for-designers.md
+++ b/src/_documentation/for-designers.md
@@ -27,57 +27,52 @@ Before getting started, we recommend that you get familiar with the VA.gov Desig
 - **[Patterns](../patterns):**  How components, content strategy, information architecture, accessibility, and visual design work in tandem to solve Veterans' needs. Here, you will find information on how Hub pages are structured, how to build multi-part forms, etc.
 - **[Layout](../layout):** The layout section describes the **design grid** and tools you can use to create page or design pattern structure.
 
-
 ## Design resources
 
-The website displays HTML and CSS examples of the various components and patterns in use on VA.gov. You can use your browser’s web inspector to view the specs for each component. However, if you use Sketch, each of these components have been added to a pattern library as well.
-
-<ul class="usa-unstyled-list">
-  <li><a href="{{ site.baseurl }}/downloads/VA-gov-Pattern-Library.sketch"><span class="fa fa-download vads-u-display--inline-block vads-u-margin-right--1"></span>Download the Sketch Pattern Library</a></li>
-</ul>
+The website displays HTML and CSS examples of the various components and patterns in use on VA.gov. You can use your browser’s web inspector to view the specs for each component. If you use Sketch, each of the components has been added to a VA pattern library as well.
 
 ## Sketch for Teams at VA
 
-Design teams at VA use Sketch for Teams to view, share, and collaborate on our work. Only designers actively working on products at VA.gov can be added to Sketch for Teams.
+Design teams at VA use Sketch for Teams to view, share, and collaborate on our work. Only designers actively working on products at VA.gov can be added to Sketch for Teams. Once you have been added, you may access the [VA pattern library](https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156) in the cloud or via download.
 
 ### Get added to Sketch for Teams
 
 1. Go to [sketch.com](https://www.sketch.com/signup) and create a Sketch account 
-2. In the #design channel in Slack, ping a Sketch for Teams admin (currently Kevin Hoffman or Ryan Thurlwell) requesting to be added
+2. In the #design channel in Slack, ping a Sketch for Teams admin (currently Ryan Thurlwell) requesting to be added
 3. Receive the invite via email, accept the invitation
 4. Boom, you're in! 
 
 ### Using Sketch for Teams
 
-Sketch for Teams works very similar to "normal" Sketch, but contains a few big features that help teams work together:
+Sketch for Teams contains a few important features that help teams work together:
 
 - Files (including libraries) live in the cloud, rather than locally on your machine
-- You can see what everyone else is doing
-- You receive Library updates automagiclly
-- Developers can inspect any element on a page, anytime
+- You receive library updates automatically (a big advantage of using Sketch for Teams)
+- You can see what everyone else is working on in the VA workspace
+- Developers can inspect any element on a page
 
-To get started on a new project, there are only a couple steps:
+To get started on a new project, there are only a couple of steps:
 
-1. Duplicate and rename the [Sketch for Teams Template](https://www.sketch.com/s/2f665c26-160d-474e-b5cc-bb94e73bb91a) into your team's folder
+1. Duplicate and rename the [Sketch for Teams Template](https://www.sketch.com/s/2f665c26-160d-474e-b5cc-bb94e73bb91a) in your team's folder
 2. In the Sketch app, go to Sketch > Preferences > Libraries and add the VA-gov-Pattern-Library.
 
 ### Libraries
 
-Do not modify VA-gov-Pattern-Library. Only OCTO-DE and the Design System Team should edit the library. 
+Do not modify the VA-gov-Pattern-Library. Only OCTO-DE and the Design System Team should edit the library. If you have questions about how to use component symbols, contact Natalie Hill, the Design System Team's UX Designer.
 
 **Load the VA.gov pattern library**
 
-Use the master VA.gov pattern library to access components, page templates, and mark up in order to design things.
+Use the master VA.gov pattern library to access components, page templates, and mark up tags for your work.
 
 In Sketch for Teams, the master library lives in the cloud, which means you no longer have to manually download the library every time it’s updated.
 
 To access and enable the master VA.gov pattern library, follow these steps:
 
-1. In Sketch, open the **preference panel** (or press `command` and `,` )
-2. In the preferences panel, select the **Libraries tab**
-3. You should see a section called VA.gov Design Cloud Libraries. Select the library named “**VA-gov-Pattern-Library**”
+1. In the Sketch menu bar, navigate to Sketch > Preferences (or press `command` and `,` ) to open the **Preferences modal**
+2. In the modal, select the **Libraries tab**
+3. You should see a section called VA.gov Design Libraries. Select the checkbox next to the library named “**VA-gov-Pattern-Library**”
 
-Once you’ve loaded the library, you should be able to access everything in it by going to **Insert** > **Symbols** > **VA-gov-Pattern-Library**
+Once you’ve loaded the library, you should be able to access everything in it by navigating to **Insert** > **Symbols** > **VA-gov-Pattern-Library**.
 
 ### Naming conventions
 
@@ -119,5 +114,5 @@ Artboard naming conventions should reflect the page they reside just like breadc
 
 ### Leaving Sketch for Teams
 
-People change projects frequently, and we have a limited number of licenses for Sketch for Teams. If you roll off work at VA or no longer use Sketch for Teams, please email Kevin Hoffman.
+People change projects frequently, and we have a limited number of licenses for Sketch for Teams. If you roll off work at VA or no longer use Sketch for Teams, please email Ryan Thurwell.
 


### PR DESCRIPTION
Removed download link for Pattern library in GitHub (it was out of date, and we want to encourage Sketch for Teams usage) and updated verbiage around accessing Sketch for Teams and the VA pattern library.