### PR TITLE
Add web component custom events documentation

### DIFF
--- a/src/_documentation/for-developers.md
+++ b/src/_documentation/for-developers.md
@@ -119,6 +119,8 @@ const element = document.querySelector('va-example-component');
 element.addEventListener('vaChange', event => { /* your listener */ })
 ```
 
+The majority of our web components also fire a `component-library-analytics` event used to translate component library actions into analytics data layer events. The event handler for this event exists in `vets-website`.
+
 ### Implementing design work
 
 When a designer hands off work, it is vital to work through potential implications that design may have on Formation. Are there any new variations on components? Are there any new components not present on this site? For more on that process, read about how to contribute.

--- a/src/_documentation/for-developers.md
+++ b/src/_documentation/for-developers.md
@@ -111,7 +111,7 @@ const exampleFunction = () => console.log("Hello, World!");
 #### Custom Events
 Some of the Design System web components allow for custom events.
 
-If you must use custom events and you're not using JSX, you must add an event listener using the event name as the event type. Given an event named `vaChange`, use: 
+If you must use custom events and you're **not** using JSX, you must add an event listener using the event name as the event type. Given an event named `vaChange`, use: 
 ```js
 const element = document.querySelector('va-example-component');
 element.addEventListener('vaChange', event => { /* your listener */ })

--- a/src/_documentation/for-developers.md
+++ b/src/_documentation/for-developers.md
@@ -109,7 +109,7 @@ const exampleFunction = () => console.log("Hello, World!");
 ```
 
 #### Custom Events
-Some of the Design System web components have custom events.
+Some of the Design System web components allow for custom events.
 
 If you must use custom events and you're not using JSX, you must add an event listener using the event name as the event type. Given an event named `vaChange`, use: 
 ```js

--- a/src/_documentation/for-developers.md
+++ b/src/_documentation/for-developers.md
@@ -111,12 +111,13 @@ const exampleFunction = () => console.log("Hello, World!");
 #### Custom Events
 Some of the Design System web components allow for custom events.
 
+If you must use custom events and you're using JSX, you must prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
+
 If you must use custom events and you're **not** using JSX, you must add an event listener using the event name as the event type. Given an event named `vaChange`, use: 
 ```js
 const element = document.querySelector('va-example-component');
 element.addEventListener('vaChange', event => { /* your listener */ })
 ```
-If you must use custom events and you're using JSX, you must prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
 
 ### Implementing design work
 

--- a/src/_documentation/for-developers.md
+++ b/src/_documentation/for-developers.md
@@ -95,7 +95,7 @@ We make our best efforts to avoid creating web components with object or array p
 If the Design System web components will be used in a React application, you are ready to use them unless:
 
 - You must pass in a function, object or array to a web component's properties
-- You must listen to custom events
+- You must use custom events
 
 **If your use case is listed above, you will have to use our web component bindings for React.** If you are not sure if you need to use a custom event, please refer to the web component's Storybook documentation to see its events and properties.
 
@@ -107,6 +107,16 @@ const exampleFunction = () => console.log("Hello, World!");
 
 <VaExampleComponent exampleProp={exampleFunction} />
 ```
+
+#### Custom Events
+Some of the Design System web components have custom events.
+
+If you must use custom events and you're not using JSX, you must add an event listener using the event name as the event type. Given an event named `vaChange`, use: 
+```js
+const element = document.querySelector('va-example-component');
+element.addEventListener('vaChange', event => { /* your listener */ })
+```
+If you must use custom events and you're using JSX, you must prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
 
 ### Implementing design work
 


### PR DESCRIPTION
## Description
Part of https://github.com/department-of-veterans-affairs/component-library/pull/270

## Testing done
N/A

## Screenshots
<img width="575" alt="Screen Shot 2022-01-26 at 12 21 36" src="https://user-images.githubusercontent.com/36863582/151214057-8ac22b96-4833-4589-92ca-0b000d2b4b5a.png">


## Acceptance criteria
- [x] Update web component usage documentation to include custom events

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
