### PR TITLE
CHORE: added new omb info page in docs

### DIFF
--- a/src/_components/buttons.md
+++ b/src/_components/buttons.md
@@ -27,7 +27,7 @@ Use the **wizard** button to trigger a [wizard](https://design.va.gov/patterns/w
 {% include storybook-preview.html story="components-buttons--primary" %}
 
 ### What to use for primary call to actions that link to another page 
-Accessibility specialists have determined that calls to action that bring a user to another page should be replaced with more visually prominent links rather than buttons due to confusion with screen readers. Read [Action link](https://design.va.gov/components/action-links) documentation for more details. We encourage using green buttons for triggering wizards only. 
+Accessibility specialists have determined that calls to action that bring a user to another page should be replaced with more visually prominent links rather than buttons due to confusion with screen readers. Read [Action link](https://design.va.gov/experimental-design/action_links) documentation for more details. We encourage using green buttons for triggering wizards only. 
 
 ## Secondary button
 
@@ -60,7 +60,7 @@ Only `<button>` elements can be disabled with a `disabled` attribute. To make a 
 
 ### When to consider something else
 * For navigation between pages of a website, default to using links.
-* For a visually prominent call to action that links to another page, use an [Action link](https://design.va.gov/components/action-links)
+* For a visually prominent call to action that links to another page, use an [Action link](https://design.va.gov/experimental-design/action_links)
 * Buttons vs text links can be confusing. A good rule is if the action changes the url, it should not be a button.
 
 ### How to use buttons
@@ -81,7 +81,7 @@ Only `<button>` elements can be disabled with a `disabled` attribute. To make a 
 * Buttons should display a visible focus state when users tab to them.
 * Avoid using `<div>` or `<img>` tags to create buttons. Screen readers don't automatically know either is a usable button.
 * Include more contextual information in the button label for screen readers. You can use an aria label to specify form numbers or program names in the buttons for greater context. 
-* It is important to use [Action links](https://design.va.gov/components/action-links) for calls to actions that link to another page rather than buttons, because screen readers always say “link” before links, and “button” before buttons. 
+* It is important to use [Action links](https://design.va.gov/experimental-design/action_links) for calls to actions that link to another page rather than buttons, because screen readers always say “link” before links, and “button” before buttons. 
 * Button and link confusion can be very frustrating for assistive technology users. A user with a screen reader may pull up a list of links and may not find a specific link because it turns out that it has actually been designated as a button in the markup. 
-* Using buttons and links intentionally results in a more inclusive experience for assistive technology users. Make sure to read both button and [action link](https://design.va.gov/components/action-links) guidance to determine what is needed for a page. 
+* Using buttons and links intentionally results in a more inclusive experience for assistive technology users. Make sure to read both button and [action link](https://design.va.gov/experimental-design/action_links) guidance to determine what is needed for a page. 
 

--- a/src/_components/omb-info.md
+++ b/src/_components/omb-info.md
@@ -43,26 +43,7 @@ OMB Info should appear at the bottom of a form introduction page and show:
 Use an OMB info control at the bottom of a form introduction page.
 
 
-### When to consider something else
-
-Consider another solution if:
-
-* When to consider something else.
-
-
 ### Behavior
 
 * All text is static with the exception of privacy act
 * Privacy Act is a link which opens in a modal window
-
-
-## Accessibility considerations
-
-* Consideration 1
-* Consideration 2
-
-
-## Related
-
-* Related Item 1
-* Related Item 2

--- a/src/_components/omb-info.md
+++ b/src/_components/omb-info.md
@@ -1,0 +1,68 @@
+---
+layout: default
+sub_section: omb-info
+title: OMB info
+anchors:
+  - anchor: Default
+  - anchor: Without OMB Number
+  - anchor: Without Response Burden
+  - anchor: With Custom Respondent Burden Benefit Type
+---
+
+# OMB info
+
+OMB Info should appear at the bottom of a form introduction page and show:
+ - Respondent burden
+ - OMB control number
+ - Expiration date 
+ - Privacy act (link)
+
+## Examples
+
+### Default
+
+{% include storybook-preview.html story="components-ombinfo--default" %}
+
+### Without OMB Number
+
+{% include storybook-preview.html story="components-ombinfo--without-omb-number" %}
+
+### Without Response Burden
+
+{% include storybook-preview.html story="components-ombinfo--without-response-burden" %}
+
+### With Custom Respondent Burden Benefit Type
+
+{% include storybook-preview.html story="components-ombinfo--with-custom-respondent-burden-benefit-type" %}
+
+
+## Usage
+
+### When to use OMB info
+
+Use an OMB info control at the bottom of a form introduction page.
+
+
+### When to consider something else
+
+Consider another solution if:
+
+* When to consider something else.
+
+
+### Behavior
+
+* All text is static with the exception of privacy act
+* Privacy Act is a link which opens in a modal window
+
+
+## Accessibility considerations
+
+* Consideration 1
+* Consideration 2
+
+
+## Related
+
+* Related Item 1
+* Related Item 2


### PR DESCRIPTION
## Description
[Ticket #35397](https://app.zenhub.com/workspaces/vsp-design-system-5f8de67192551b0012ebb802/issues/department-of-veterans-affairs/va.gov-team/35397)
New page omb-info.md file was added.  This file contains all that is needed for the Jekyll build process to generate the HTML page with the examples on it, as well as add the necessary items to the left hand navigation.  
Still working on the Accessibility section.  There is just placeholder text in that section currently.

## Screenshots
![image](https://user-images.githubusercontent.com/5603893/153236087-22a4c501-c816-497f-87cb-0ddd8b52e1da.png)

## Acceptance criteria
- [X] Add OMBInfo documentation to design.va.gov
- [ ] Check with Natalie and Courtney about any design or accessibility considerations

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)








