### PR TITLE
fix: add missing comma to storybook link

### DIFF
--- a/src/_components/telephone.md
+++ b/src/_components/telephone.md
@@ -14,7 +14,7 @@ The `va-telephone` component also follows the guidelines set for <a href="https:
 
 ## Default
 
-{% include storybook-preview.html story=components-va-telephone--default" height="80px" %}
+{% include storybook-preview.html story="components-va-telephone--default" height="80px" %}
 
 ## Three Digit Number
 


### PR DESCRIPTION
There was a missing comma in a telephone Storybook link that was causing tests to fail.