### PR TITLE
Changing link on page and section title page

### DIFF
--- a/src/_content-style-guide/page-titles-and-section-titles.md
+++ b/src/_content-style-guide/page-titles-and-section-titles.md
@@ -41,7 +41,7 @@ Section and subsection titles (also sometimes called headers and subheads) help 
 
 We allow a little more character count for sections and subsections than page titles. But in general, sections become hard to scan when they're too long. Eliminate unnecessary details or nuance in section and subsection titles, and address them with more depth in the paragraph copy.
 
-For more information about structuring sections using H2s and H3s, see [How to use headings](https://yoast.com/how-to-use-headings-on-your-site/) on Yoast.com.
+[Read more about using header levels to structure sections on W3.org](https://www.w3.org/WAI/tutorials/page-structure/headings/)
 
 <div class="do-dont">
 <div class="do-dont__do">


### PR DESCRIPTION
@bethpottsVADEPO asked Sitewide Content to replace the Yoast.com link on the [Page titles and section titles](https://design.va.gov/content-style-guide/page-titles-and-section-titles) page with this: https://www.w3.org/WAI/tutorials/page-structure/headings/

I update the text to match our current link style.