### PR TITLE
37935 Remove React Components from Storybook

### DIFF
--- a/src/_components/additional-info.md
+++ b/src/_components/additional-info.md
@@ -4,11 +4,6 @@ sub_section: additional-info
 title: Additional info
 ---
 
-<div class="vads-u-background-color--gold vads-u-padding--2 vads-u-display--inline-block vads-u-width--auto vads-u-margin-bottom--5">
-  <p class="vads-u-margin--0  vads-u-measure--5"><strong>Additional info panels
-  are currently only available in the React component library. Read about the <a href="https://design.va.gov/storybook/?path=/docs/components-additionalinfo--default">AdditionalInfo component</a>.</strong></p>
-</div>
-
 # Additional info
 
 {% include storybook-preview.html story="components-va-additional-info--default" %}


### PR DESCRIPTION
## Chromatic
<!-- This `37935-remove-react-components-sb` is a placeholder for a CI job - it will be updated automatically -->
https://37935-remove-react-components-sb--60f9b557105290003b387cd5.chromatic.com

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/37935

## Testing done / Screenshots
<img width="162" alt="Screen Shot 2022-03-30 at 11 54 11 AM" src="https://user-images.githubusercontent.com/11822533/160882255-e8a66ab9-53b3-4af4-9dca-a64421504ce6.png">

## Related PR on Documentation
https://github.com/department-of-veterans-affairs/component-library/pull/339

## Acceptance criteria
- [X] Storybook stories for deprecated React components have been removed
- [X] design.va.gov has been checked and all Storybook iframes are working

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
