### PR TITLE
Add warning about column sort in IE11

### DIFF
--- a/src/_components/tables.md
+++ b/src/_components/tables.md
@@ -33,6 +33,7 @@ anchors:
   - Do not center align.
 - **Wrap instead of truncate content.** This reduces confusion in case headers start with the same word.
 - **Be selective about using column sort.**
+  - **Note:** column sort does not work in IE11
   - Sort should only be included in a table if it can assist the user in completing a task.
   - Only one column per table should be sortable, keep it simple.
   - A default sort order (ascending or descending) must be defined.


### PR DESCRIPTION
## Description

The design.va.gov portion of https://github.com/department-of-veterans-affairs/component-library/pull/348. Add a warning about sort functionality for `<va-table>` in IE11