### PR TITLE
Update Modal link and link text to Storybook

### DIFF
--- a/src/_components/modal.md
+++ b/src/_components/modal.md
@@ -4,10 +4,6 @@ sub_section: modal
 title: Modal
 ---
 
-<div class="vads-u-background-color--gold vads-u-padding--2 vads-u-display--inline-block vads-u-width--auto vads-u-margin-bottom--5">
-  <p class="vads-u-margin--0  vads-u-measure--5"><strong>Modals are currently only available in Formation React. Read about the <a href="https://design.va.gov/storybook/?path=/docs/components-modal--default">Modal component</a>.</strong></p>
-</div>
-
 # Modal web component
 
 {% include storybook-preview.html height="400px" story="components-va-modal--default" link_text="va-modal" %}

--- a/src/_components/modal.md
+++ b/src/_components/modal.md
@@ -10,4 +10,4 @@ title: Modal
 
 ## Crisis Line Modal
 
-{% include storybook-preview.html height="500px" story="components-modal--crisis-line-modal" %}
+{% include storybook-preview.html height="500px" story="components-va-modal--crisis-line-modal" link_text="va-modal" %}

--- a/src/_components/modal.md
+++ b/src/_components/modal.md
@@ -8,9 +8,9 @@ title: Modal
   <p class="vads-u-margin--0  vads-u-measure--5"><strong>Modals are currently only available in Formation React. Read about the <a href="https://design.va.gov/storybook/?path=/docs/components-modal--default">Modal component</a>.</strong></p>
 </div>
 
-# Modal
+# Modal web component
 
-{% include storybook-preview.html height="400px" story="components-modal--default" %}
+{% include storybook-preview.html height="400px" story="components-va-modal--default" link_text="va-modal" %}
 
 ## Crisis Line Modal
 

--- a/src/_components/modal.md
+++ b/src/_components/modal.md
@@ -4,7 +4,7 @@ sub_section: modal
 title: Modal
 ---
 
-# Modal web component
+# Modal
 
 {% include storybook-preview.html height="400px" story="components-va-modal--default" link_text="va-modal" %}
 

--- a/src/_includes/storybook-preview.html
+++ b/src/_includes/storybook-preview.html
@@ -2,4 +2,4 @@
   <iframe width="100%" height="{{ include.height }}" src="{{ site.storybook_path }}/iframe.html?id={{ include.story }}&viewMode=story"></iframe>
 </div>
 
-[See this in Storybook]({{ site.storybook_path }}/?path=/docs/{{ include.story }})
+[{% if include.link_text %}View {% endif %}{{ include.link_text && | default: 'See this' }} in Storybook]({{ site.storybook_path }}/?path=/docs/{{ include.story }})

--- a/src/_includes/storybook-preview.html
+++ b/src/_includes/storybook-preview.html
@@ -1,5 +1,12 @@
-<div class="site-showcase" style="max-width: {{ include.width | default: '100%' }}" >
-  <iframe width="100%" height="{{ include.height }}" src="{{ site.storybook_path }}/iframe.html?id={{ include.story }}&viewMode=story"></iframe>
+<div
+  class="site-showcase"
+  style="max-width: {{ include.width | default: '100%' }}"
+>
+  <iframe
+    width="100%"
+    height="{{ include.height }}"
+    src="{{ site.storybook_path }}/iframe.html?id={{ include.story }}&viewMode=story"
+  ></iframe>
 </div>
 
-[{% if include.link_text %}View {% endif %}{{ include.link_text && | default: 'See this' }} in Storybook]({{ site.storybook_path }}/?path=/docs/{{ include.story }})
+[{% if include.link_text %}View {{ include.link_text}}{% else %}See this{% endif %} in Storybook]({{ site.storybook_path }}/?path=/docs/{{ include.story }})


### PR DESCRIPTION
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/39968

<img width="1274" alt="Screen Shot 2022-04-15 at 12 11 25" src="https://user-images.githubusercontent.com/36863582/163594332-30848690-aeef-4a05-b02e-00dc9cb95016.png">

- [x] Update Storybook link url to `https://design.va.gov/storybook/?path=/docs/components-va-modal--default`
- [x] Update Storybook link text on design.va.gov to `View va-modal in Storybook`