### PR TITLE
add design system team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @department-of-veterans-affairs/platform-design-system-team


### PR DESCRIPTION
Adding the platform design system team as a codeowner for all files in this repo.