### PR TITLE
Update link text and remove mobile story for Breadcrumbs

### DIFF
--- a/src/_components/breadcrumbs.md
+++ b/src/_components/breadcrumbs.md
@@ -13,12 +13,7 @@ web-component: va-breadcrumbs
 
 ## Examples
 
-### Desktop
-{% include storybook-preview.html height="100px" story="components-breadcrumbs--default" %}
-
-
-### Mobile
-{% include storybook-preview.html height="100px" width="400px" story="components-breadcrumbs--mobile-first" %}
+{% include storybook-preview.html height="100px" story="components-va-breadcrumbs--default" link_text="va-breadcrumbs" %}
 
 
 ## Usage


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/35806

## Screenshots
<img width="1269" alt="Screen Shot 2022-04-21 at 13 13 41" src="https://user-images.githubusercontent.com/36863582/164514834-dc65190b-5647-4454-b10d-a70089cc0ca3.png">





## Acceptance Criteria
- [x] Update Storybook preview url to point to `va-breadcrumbs`
- [x] Remove mobile story
