### PR TITLE
update component-docs logic

### DIFF
--- a/src/_data/component-docs.json
+++ b/src/_data/component-docs.json
@@ -1609,7 +1609,7 @@
           "mutable": false,
           "attr": "href",
           "reflectToAttr": false,
-          "docs": "`href` attribute for the `<a>` tag.",
+          "docs": "`href` attribute for the `&lt;a&gt;` tag.",
           "docsTags": [],
           "values": [
             {

--- a/src/_includes/component-docs.html
+++ b/src/_includes/component-docs.html
@@ -1,8 +1,8 @@
 {% for component in site.data.component-docs.components %} {% if component.tag
   == include.component_name %}
-{% unless compoenent.props == empty %} {% unless component.events == empty %}
+{% if component.props != empty or component.events != empty %}
 <h2 id="code-usage">Code usage</h2>
-{% unless component.props == empty %}
+{% if component.props != empty %}
 <h3>Attributes and Properties</h3>
 <table>
   <tr>
@@ -24,9 +24,9 @@
     {% endfor %}
   </div>
 </table>
-{% endunless %}
+{% endif %}
 
-{% unless component.events == empty %}
+{% if component.events != empty %}
 <h3>Events</h3>
 <table>
   <tr>
@@ -48,5 +48,5 @@
     {% endfor %}
   </div>
 </table>
-{% endunless %}
-{% endunless %} {% endunless %} {% endif %} {% endfor %}
+{% endif %}
+{% endif %} {% endif %} {% endfor %}

--- a/src/_includes/component-docs.html
+++ b/src/_includes/component-docs.html
@@ -1,4 +1,8 @@
+{% for component in site.data.component-docs.components %} {% if component.tag
+  == include.component_name %}
+{% unless compoenent.props == empty %} {% unless component.events == empty %}
 <h2 id="code-usage">Code usage</h2>
+{% unless component.props == empty %}
 <h3>Attributes and Properties</h3>
 <table>
   <tr>
@@ -8,8 +12,6 @@
     <th><strong>Default</strong></th>
     <th><strong>Description</strong></th>
   </tr>
-  {% for component in site.data.component-docs.components %} {% if component.tag
-  == include.component_name %}
   <div>
     {% for prop in component.props %}
     <tr>
@@ -21,17 +23,16 @@
     </tr>
     {% endfor %}
   </div>
-  {% endif %} {% endfor %}
 </table>
+{% endunless %}
 
+{% unless component.events == empty %}
 <h3>Events</h3>
 <table>
   <tr>
     <th><strong>Name</strong></th>
     <th><strong>Description</strong></th>
   </tr>
-  {% for component in site.data.component-docs.components %} {% if component.tag
-  == include.component_name %}
   <div>
     {% for event in component.events %}
     <tr>
@@ -46,5 +47,6 @@
     </tr>
     {% endfor %}
   </div>
-  {% endif %} {% endfor %}
 </table>
+{% endunless %}
+{% endunless %} {% endunless %} {% endif %} {% endfor %}


### PR DESCRIPTION
Updates the component-docs logic so that when a component does not have any props or events, the code usage section is not added to the page.