### PR TITLE
chore: fix links for In This Section

### DIFF
--- a/src/_includes/_site-in-this-section.html
+++ b/src/_includes/_site-in-this-section.html
@@ -1,16 +1,17 @@
 {% if page.sub-pages %}
 <nav aria-labelledby="in-this-section" class="site-in-this-section">
-  <h2 id="on-this-page" class="site-in-this-section__title">
-    In this section
-  </h2>
+  <h2 id="on-this-page" class="site-in-this-section__title">In this section</h2>
   <ul class="site-in-this-section__list">
-  {% for item in page.sub-pages%}
+    {% for item in page.sub-pages%}
     <dd role="definition" class="site-in-this-section__definition">
-      <a class="site-in-this-section__link" href="{{ page.url }}/{{ item.sub-page | slugify }}">
+      <a
+        class="site-in-this-section__link"
+        href="{{ page.url }}{{ item.sub-page | slugify }}"
+      >
         {{ item.sub-page }}
       </a>
     </dd>
-  {% endfor %}
+    {% endfor %}
   </ul>
 </nav>
 {% endif %}


### PR DESCRIPTION
This PR removes the extra slash in URLs in `In This Section`.

<img width="1792" alt="Screen Shot 2022-04-27 at 09 20 25" src="https://user-images.githubusercontent.com/36863582/165527332-7a546d06-c234-4fa0-b7a2-8969be273567.png">
<img width="1792" alt="Screen Shot 2022-04-27 at 09 20 18" src="https://user-images.githubusercontent.com/36863582/165527341-92a9d146-7345-49e1-8e26-5715250a99ec.png">
