### PR TITLE
Bump Component Library v8.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
       }
     },
     "@department-of-veterans-affairs/component-library": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-8.6.2.tgz",
-      "integrity": "sha512-U6M9J94N4JUwbUDqTK1oIZbtGLjYjqJ/PCTVifr2c+FCXPledX8uEVxQELBwechSMkGwxznBl2GUBHzCe4vEyA==",
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-8.6.3.tgz",
+      "integrity": "sha512-25ngKTeAYa1o1o4OAnO8VHPBbR7gdD/IopII45dPythG3fLlrv6U6BiBm/yKD7SzZSfS4PN8ExRl+W1xBw3o7w==",
       "dev": true,
       "requires": {
         "@department-of-veterans-affairs/react-components": "6.0.0",
-        "@department-of-veterans-affairs/web-components": "2.12.2",
+        "@department-of-veterans-affairs/web-components": "2.12.3",
         "i18next": "^21.6.14",
         "i18next-browser-languagedetector": "^6.1.4",
         "react-focus-on": "^3.5.1",
@@ -54,9 +54,9 @@
       }
     },
     "@department-of-veterans-affairs/web-components": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-2.12.2.tgz",
-      "integrity": "sha512-02lHOeF9B/PWzWUv0WF+E6wQvta6SMju3IP/6xT5xwj8K92K3SKcDl4q5M9Oo2jCLNirsOFLWY8Vm2QifdP0zQ==",
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-2.12.3.tgz",
+      "integrity": "sha512-zk5Fkh/TakUpE8h7Q9TrIh9iOmhB2aBE4hJCSNvrjhW1k0RAMnq1/DOmS2QbOgadoxukpWvmTZxMsDTwnbGlZQ==",
       "dev": true,
       "requires": {
         "@stencil/core": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/department-of-veterans-affairs/vets-design-system-documentation#readme",
   "devDependencies": {
-    "@department-of-veterans-affairs/component-library": "^8.6.2",
+    "@department-of-veterans-affairs/component-library": "^8.6.3",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-rename": "^2.0.0",


### PR DESCRIPTION
Bump to latest to fix issues with JSDoc and `<input>` elements