### PR TITLE
Fit content inside iframe

### DIFF
--- a/src/_components/alert.md
+++ b/src/_components/alert.md
@@ -47,7 +47,7 @@ Used to prompt a user to sign in, create an account, or launch an online tool to
 
 Any style of alert box can be modified to be a background-color-only alert. Use background alerts for immediate feedback, such as in single-page applications or Ajax forms. They shouldn’t be used for static alert messaging.
 
-{% include storybook-preview.html story="components-va-alert--background-only" height="80px" %}
+{% include storybook-preview.html story="components-va-alert--background-only" height="352px" %}
 
 - Some users might not be able to distinguish differences in the background color or see the color at all. Don’t rely on color alone to convey context. 
 - Messaging should be direct and concise. Aim for one or two lines.
@@ -57,7 +57,7 @@ Any style of alert box can be modified to be a background-color-only alert. Use 
 
 A background alert may be used with an icon to draw attention to important feedback. The iconography for background alerts is consistent with the way icons are used in standard alert boxes.
 
-{% include storybook-preview.html story="components-va-alert--background-only-with-icon" height="80px" %}
+{% include storybook-preview.html story="components-va-alert--background-only-with-icon" height="352px" %}
 
 ### Full-width alerts
 

--- a/src/_components/alert.md
+++ b/src/_components/alert.md
@@ -47,7 +47,7 @@ Used to prompt a user to sign in, create an account, or launch an online tool to
 
 Any style of alert box can be modified to be a background-color-only alert. Use background alerts for immediate feedback, such as in single-page applications or Ajax forms. They shouldn’t be used for static alert messaging.
 
-{% include storybook-preview.html story="components-va-alert--background-only" height="352px" %}
+{% include storybook-preview.html story="components-va-alert--background-only" %}
 
 - Some users might not be able to distinguish differences in the background color or see the color at all. Don’t rely on color alone to convey context. 
 - Messaging should be direct and concise. Aim for one or two lines.
@@ -57,7 +57,7 @@ Any style of alert box can be modified to be a background-color-only alert. Use 
 
 A background alert may be used with an icon to draw attention to important feedback. The iconography for background alerts is consistent with the way icons are used in standard alert boxes.
 
-{% include storybook-preview.html story="components-va-alert--background-only-with-icon" height="352px" %}
+{% include storybook-preview.html story="components-va-alert--background-only-with-icon" %}
 
 ### Full-width alerts
 

--- a/src/_components/banner.md
+++ b/src/_components/banner.md
@@ -15,11 +15,11 @@ web-component: va-banner
 
 ### Default
 
-{% include storybook-preview.html story="components-va-banner--default" height="80px" %}
+{% include storybook-preview.html story="components-va-banner--default" height="172px" %}
 
 ### Closeable
 
-{% include storybook-preview.html story="components-va-banner--closeable" height="80px" %}
+{% include storybook-preview.html story="components-va-banner--closeable" height="172px" %}
 
 ## Usage
 

--- a/src/_components/banner.md
+++ b/src/_components/banner.md
@@ -15,11 +15,11 @@ web-component: va-banner
 
 ### Default
 
-{% include storybook-preview.html story="components-va-banner--default" height="172px" %}
+{% include storybook-preview.html story="components-va-banner--default" %}
 
 ### Closeable
 
-{% include storybook-preview.html story="components-va-banner--closeable" height="172px" %}
+{% include storybook-preview.html story="components-va-banner--closeable" %}
 
 ## Usage
 

--- a/src/_includes/storybook-preview.html
+++ b/src/_includes/storybook-preview.html
@@ -3,10 +3,18 @@
   style="max-width: {{ include.width | default: '100%' }}"
 >
   <iframe
+    id="{{ include.story }}"
     width="100%"
     height="{{ include.height }}"
     src="{{ site.storybook_path }}/iframe.html?id={{ include.story }}&viewMode=story"
   ></iframe>
 </div>
+
+<script>
+  window["{{ include.story }}"] = document.getElementById("{{ include.story }}");
+  window["{{ include.story }}"].onload = function() {
+    window["{{ include.story }}"].style.height = window["{{ include.story }}"].contentWindow.document.body.scrollHeight + "px";
+  }
+</script>
 
 [{% if include.link_text %}View {{ include.link_text}}{% else %}See this{% endif %} in Storybook]({{ site.storybook_path }}/?path=/docs/{{ include.story }})


### PR DESCRIPTION
## Screenshots
![Screen Shot 2022-04-27 at 18 33 23](https://user-images.githubusercontent.com/36863582/165642288-d4675265-404a-4f46-8f9c-a17f45a19306.png)
![Screen Shot 2022-04-27 at 18 33 08](https://user-images.githubusercontent.com/36863582/165642292-fbf659d8-6607-4a1a-a89f-a22179103cc7.png)

## Alternative Solution
We might be able to set the iframe height dynamically to fit its contents, but I haven't been able to test it locally because of cross-origin errors (Storybook runs on a different port locally). I think this would be considered "same-origin" on production? @bkjohnson @pdavies88 @k80bowman 
![Screen Shot 2022-04-27 at 18 36 12](https://user-images.githubusercontent.com/36863582/165642630-564f1ce2-b628-4104-bc83-abfe631d4b02.png)

```diff
diff --git a/src/_includes/storybook-preview.html b/src/_includes/storybook-preview.html
index 1d19f9a..e862345 100644
--- a/src/_includes/storybook-preview.html
+++ b/src/_includes/storybook-preview.html
@@ -3,10 +3,18 @@
   style="max-width: {{ include.width | default: '100%' }}"
 >
   <iframe
+    id="{{ include.story }}"
     width="100%"
     height="{{ include.height }}"
     src="{{ site.storybook_path }}/iframe.html?id={{ include.story }}&viewMode=story"
   ></iframe>
 </div>
 
+<script>
+  window["{{ include.story }}"] = document.getElementById("{{ include.story }}");
+  window["{{ include.story }}"].onload = function() {
+    window["{{ include.story }}"].style.height = window["{{ include.story }}"].contentWindow.document.body.scrollHeight + "px";
+  }
+</script>
+
 [{% if include.link_text %}View {{ include.link_text}}{% else %}See this{% endif %} in Storybook]({{ site.storybook_path }}/?path=/docs/{{ include.story }})
```