### PR TITLE
Add issues to board

### DIFF
--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -1,0 +1,16 @@
+name: Project automation
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add_issue_to_project:
+    name: Add new issues to project board
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh api graphql -f query='mutation($project:ID!, $issue:ID!) { addProjectNextItem(input: {projectId: $project, contentId: $issue}) { projectNextItem { id }  } }' -f project=${{ secrets.PROJECT_BOARD_ID }} -f issue=${{ github.event.issue.node_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -13,4 +13,4 @@ jobs:
       - run: |
           gh api graphql -f query='mutation($project:ID!, $issue:ID!) { addProjectNextItem(input: {projectId: $project, contentId: $issue}) { projectNextItem { id }  } }' -f project=${{ secrets.PROJECT_BOARD_ID }} -f issue=${{ github.event.issue.node_id }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add new issues to project board
     runs-on: ubuntu-latest
     steps:
-      - name: Get project data
+      - name: Get project ID
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORGANIZATION: department-of-veterans-affairs
@@ -21,13 +21,6 @@ jobs:
               organization(login: $org){
                 projectNext(number: $number) {
                   id
-                  fields(first:20) {
-                    nodes {
-                      id
-                      name
-                      settings
-                    }
-                  }
                 }
               }
             }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json

--- a/.github/workflows/issue-automation.yml
+++ b/.github/workflows/issue-automation.yml
@@ -10,7 +10,29 @@ jobs:
     name: Add new issues to project board
     runs-on: ubuntu-latest
     steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORGANIZATION: department-of-veterans-affairs
+          PROJECT_NUMBER: ${{ secrets.PROJECT_NUMBER }}
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
       - run: |
-          gh api graphql -f query='mutation($project:ID!, $issue:ID!) { addProjectNextItem(input: {projectId: $project, contentId: $issue}) { projectNextItem { id }  } }' -f project=${{ secrets.PROJECT_BOARD_ID }} -f issue=${{ github.event.issue.node_id }}
+          gh api graphql -f query='mutation($project:ID!, $issue:ID!) { addProjectNextItem(input: {projectId: $project, contentId: $issue}) { projectNextItem { id }  } }' -f project=$PROJECT_ID -f issue=${{ github.event.issue.node_id }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This should add any new issue that gets made in this repo to the GitHub project board that I'm using to explore some features.

The work is based on:

- [this discussion comment](https://github.com/github/feedback/discussions/5378#discussioncomment-2137318)
- [documentation on project automation](https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects#example-workflow-authenticating-with-a-personal-access-token)

I'm merging this so that I can test some changes. This workflow is meant to trigger on `issue` events, and [the documentation on workflow triggers](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issues) says:

> **Note**: This event will only trigger a workflow run if the workflow file is on the default branch.
