### PR TITLE
Setup web components for use on design.va.gov

### DIFF
--- a/config/gulp/css.js
+++ b/config/gulp/css.js
@@ -9,6 +9,15 @@ gulp.task('copy-formation-css', function (done) {
   return stream;
 });
 
+gulp.task('copy-web-components-css', function (done) {
+  console.log('copying web-components CSS');
+  var stream = gulp.src('./node_modules/@department-of-veterans-affairs/web-components/dist/component-library/*.css')
+    .pipe(gulp.dest('src/assets/stylesheets/'));
+
+  return stream;
+});
+
 gulp.task(task, gulp.series(
-  'copy-formation-css'
+  'copy-formation-css',
+  'copy-web-components-css'
 ));

--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -14,7 +14,7 @@ gulp.task('copy-web-components-js', function (done) {
   console.log('copying web-components javascript');
   var stream = gulp.src(
     './node_modules/@department-of-veterans-affairs/web-components/**/*.js')
-    .pipe(gulp.dest('src/vendor/javascripts/web-components/'));
+    .pipe(gulp.dest('src/vendor/javascripts/component-library/'));
 
   return stream;
 });

--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -1,15 +1,6 @@
 var gulp = require('gulp');
 var rename = require('gulp-rename');
 
-gulp.task('copy-react-js', function (done) {
-  console.log('copying uswds javascript');
-  var stream = gulp.src('./node_modules/formation/src/components/**/*.njk')
-    .pipe(rename({dirname: ''}))
-    .pipe(gulp.dest('src/_includes/react'));
-
-  return stream;
-});
-
 gulp.task('copy-formation-js', function (done) {
   console.log('copying uswds javascript');
   var stream = gulp.src('./node_modules/@department-of-veterans-affairs/formation/dist/formation.js')

--- a/config/gulp/javascript.js
+++ b/config/gulp/javascript.js
@@ -19,5 +19,13 @@ gulp.task('copy-formation-js', function (done) {
   return stream;
 });
 
+gulp.task('copy-web-components-js', function (done) {
+  console.log('copying web-components javascript');
+  var stream = gulp.src(
+    './node_modules/@department-of-veterans-affairs/web-components/**/*.js')
+    .pipe(gulp.dest('src/vendor/javascripts/web-components/'));
 
-gulp.task('javascript', gulp.series('copy-formation-js', 'copy-react-js'));
+  return stream;
+});
+
+gulp.task('javascript', gulp.series('copy-formation-js', 'copy-web-components-js'));

--- a/src/_components/form/index.md
+++ b/src/_components/form/index.md
@@ -16,11 +16,11 @@ sub-pages:
 
 ## How to group form controls
 
-<div class="feature">
-  <h3>Forms system documentation</h3>
+<va-featured-content>
+  <h3 slot="headline">Forms system documentation</h3>
   <p>The current forms library is considered a legacy product and is in maintenance mode. A new forms library is under development.</p>
   <p>View documentation for the current forms library for VA.gov on <a href="{{ site.forms_system_link }}">the platform website</a>.</p>
-</div>
+</va-featured-content>
 
 - Group each set of thematically related controls in a `fieldset` element. Use the `legend` element as a heading within each one. The `fieldset` and `legend` elements make it easier for screen reader users to navigate the form.
 - Use a single legend for fieldset (this is required). One example of a common use of `fieldset` and `legend` is a question with radio button options for answers. The question text and radio buttons are wrapped in a fieldset, with the question itself being inside the `legend` tag.

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -22,7 +22,7 @@
     href="/assets/stylesheets/component-library.css"
   />
   <script type="module">
-    import { defineCustomElements } from "/vendor/javascripts/web-components/loader/index.es2017.js";
+    import { defineCustomElements } from "/vendor/javascripts/component-library/loader/index.es2017.js";
     defineCustomElements();
 </script>
 

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -16,11 +16,8 @@
   <meta name=”robots” content=”noindex, nofollow”>
   {% endif %}
 
-  <link
-    rel="stylesheet"
-    type="text/css"
-    href="/assets/stylesheets/component-library.css"
-  />
+  <!-- Web component setup -->
+  <link rel="stylesheet" type="text/css" href="/assets/stylesheets/component-library.css" />
   <script type="module">
     import { defineCustomElements } from "/vendor/javascripts/component-library/loader/index.es2017.js";
     defineCustomElements();

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -16,6 +16,16 @@
   <meta name=”robots” content=”noindex, nofollow”>
   {% endif %}
 
+  <link
+    rel="stylesheet"
+    type="text/css"
+    href="/assets/stylesheets/component-library.css"
+  />
+  <script type="module">
+    import { defineCustomElements } from "/vendor/javascripts/web-components/loader/index.es2017.js";
+    defineCustomElements();
+</script>
+
   <!-- Icons -->
   <link href="{{ site.baseurl }}/assets/img/favicons/apple-touch-icon.png" rel="apple-touch-icon-precomposed">
   <link href="{{ site.baseurl }}/assets/img/favicons/apple-touch-icon-72x72.png" rel="apple-touch-icon-precomposed" sizes="72x72">

--- a/src/_patterns/forms/index.md
+++ b/src/_patterns/forms/index.md
@@ -21,11 +21,11 @@ sub-pages:
 
 ## Getting Started with VA.gov Forms
 
-<div class="feature">
-  <h3>Forms system documentation</h3>
+<va-featured-content>
+  <h3 slot="headline">Forms system documentation</h3>
   <p>The current forms library is considered a legacy product and is in maintenance mode. A new forms library is under development.</p>
   <p>View documentation for the current forms library for VA.gov on <a href="{{ site.forms_system_link }}">the platform website</a>.</p>
-</div>
+</va-featured-content>
 
 _Compiled by:_ Shawna Hein, VSA Design Lead
 


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/710

This makes it possible for our web components to be used on design.va.gov. As an example I went ahead and updated the featured content components on the `components/form` and `patterns/forms` pages to use their web component versions.

## Screenshots

![va-featured-content web component in use](https://user-images.githubusercontent.com/2008881/167043919-82b7c6a2-a465-4eac-8dcd-57d1070c87bb.png)
