### PR TITLE
40187 Banner Documentation Update

### DIFF
--- a/src/_components/banner.md
+++ b/src/_components/banner.md
@@ -15,11 +15,11 @@ web-component: va-banner
 
 ### Default
 
-{% include storybook-preview.html story="components-va-banner--default" height="172px" %}
+{% include storybook-preview.html story="components-va-banner--default" height="172px" link_text="va-banner" %}
 
 ### Closeable
 
-{% include storybook-preview.html story="components-va-banner--closeable" height="172px" %}
+{% include storybook-preview.html story="components-va-banner--closeable" height="172px" link_text="va-banner" %}
 
 ## Usage
 
@@ -36,25 +36,6 @@ web-component: va-banner
 - Add a headline, type, and visible prop to have the component display on the page.
 - If the banner should not be visible, have a button to be dismissible, or be dismissed to sessionStorage instead of localStorage additional props can be added to accommodate.
 
-### Technical Documentation on va-banner
-
-Props Available:
-- headline 
-    - This prop takes in a string and is used as the headline text of the `va-banner` component.
-- show-close	
-    - This prop is a boolean and is optional. When it is set to true it enables the close functionality via a close button. When clicked the banner will be closed until storage is cleared.
-- disable-analytics
-    - This prop is a boolean and is optional. When it is set to true the component-library-analytics event that is set to track usage on Vets Website via Google Tag Manager will be disabled.
-- type
-    - This prop takes in a string of 'info', 'error', 'success', 'continue', or 'warning'. This affects both the icon of the child `va-alert` component and the top border color.
-- visible
-    - This prop is a boolean. When false the banner will not visibly render on the page.
-- window-session
-    - This prop is a boolean and is optional. When enabled sessionStorage for the `va-banner` will be used otherwise, the component when show close is enabled, will default to localStorage.
-
-Events Available:
-- component-library-analytics
-    - This event is used to track usage of the component in Vets Website via Google Tag Manager and is emitted when clicking on an anchor link. **Note: This event is read only and cannot be customized**
 
 {% include component-docs.html component_name=page.web-component %}
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/40187

## Related PR
https://github.com/department-of-veterans-affairs/component-library/pull/430

## Testing done - Screenshots
<img width="996" alt="Screen Shot 2022-05-18 at 10 15 54 AM" src="https://user-images.githubusercontent.com/11822533/169063452-ceacf565-ba4d-4b2f-ad36-c2ad3c783280.png">

## Acceptance criteria
- [x] Banner link to Storybook is labeled "View va-banner in Storybook"
- [x] Height of the Storybook preview doesn't require scrolling on design.va.gov
- [x] The extra section with Technical Documentation has been removed

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)