### PR TITLE
Update Textarea documentation

### DIFF
--- a/src/_components/form/index.md
+++ b/src/_components/form/index.md
@@ -11,7 +11,8 @@ sub-pages:
   - sub-page: Number input
   - sub-page: Radio button
   - sub-page: Select
-  - sub-page: Text inputs
+  - sub-page: Text input
+  - sub-page: Textarea
 ---
 
 {% include _site-in-this-section.html %}

--- a/src/_components/form/text-input.md
+++ b/src/_components/form/text-input.md
@@ -1,9 +1,9 @@
 ---
 layout: component
-permalink: /components/form/text-inputs
+permalink: /components/form/text-input
 has-parent: /components/form/
-title: Text inputs
-intro-text: "Text inputs allow people to enter any type of text unless otherwise restricted."
+title: Text input
+intro-text: "Text input allows people to enter any type of text unless otherwise restricted."
 research-title: Form controls
 sketch-link: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/04A043C5-65CA-43BB-88F2-E17EF8B12D7D
 status: use-deployed
@@ -36,7 +36,7 @@ Note that in general we want to avoid this pattern - if a field needs a lot of e
 
 ## Usage
 
-### When to use text inputs
+### When to use text input
 
 - If you can’t reasonably predict a user’s answer to a prompt and there might be wide variability in users’ answers.
 - When using another type of input will make answering more difficult. For example, birthdays and other known dates are easier to type in than they are to select from a calendar picker.
@@ -49,7 +49,7 @@ Note that in general we want to avoid this pattern - if a field needs a lot of e
 ### How to use 
 
 - The length of the text input provides a hint to users as to how much text to write. Do not require users to write paragraphs of text into a single-line input box; use a [textarea]({{ site.baseurl }}/components/form/textarea) instead.
-- Text inputs are among the easiest type of input for desktop users but are more difficult for mobile users. Consider using specific `pattern` attributes or `type="tel"` or `type="number"` to trigger specific mobile keyboards.
+- Text input is among the easiest type of input for desktop users but are more difficult for mobile users. Consider using specific `pattern` attributes or `type="tel"` or `type="number"` to trigger specific mobile keyboards.
 - Only show error validation messages or stylings after a user has interacted with a particular field.
 - Avoid using placeholder text that appears within a text field before a user starts typing. If placeholder text is no longer visible after a user clicks into the field, users will no longer have that text available when they need to review their entries. (People who have cognitive or visual disabilities have additional problems with placeholder text.)
 

--- a/src/_components/form/text-inputs.md
+++ b/src/_components/form/text-inputs.md
@@ -3,13 +3,12 @@ layout: component
 permalink: /components/form/text-inputs
 has-parent: /components/form/
 title: Text inputs
-intro-text: "Text inputs (text-input and textarea) allow people to enter any type of text unless otherwise restricted."
+intro-text: "Text inputs allow people to enter any type of text unless otherwise restricted."
 research-title: Form controls
 sketch-link: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/04A043C5-65CA-43BB-88F2-E17EF8B12D7D
 status: use-deployed
 anchors:
   - anchor: Text input
-  - anchor: Text area
   - anchor: Usage
   - anchor: How to use
   - anchor: Code usage
@@ -35,10 +34,6 @@ Note that in general we want to avoid this pattern - if a field needs a lot of e
 
 {% include storybook-preview.html story="components-va-text-input--with-hint-text" link_text="va-text-input--with-hint-text" %}
 
-## Text area
-
-{% include storybook-preview.html height="300px" story="components-textarea--default" %}
-
 ## Usage
 
 ### When to use text inputs
@@ -53,7 +48,7 @@ Note that in general we want to avoid this pattern - if a field needs a lot of e
 
 ### How to use 
 
-- The length of the text input provides a hint to users as to how much text to write. Do not require users to write paragraphs of text into a single-line input box; use a text area instead.
+- The length of the text input provides a hint to users as to how much text to write. Do not require users to write paragraphs of text into a single-line input box; use a [textarea]({{ site.baseurl }}/components/form/textarea) instead.
 - Text inputs are among the easiest type of input for desktop users but are more difficult for mobile users. Consider using specific `pattern` attributes or `type="tel"` or `type="number"` to trigger specific mobile keyboards.
 - Only show error validation messages or stylings after a user has interacted with a particular field.
 - Avoid using placeholder text that appears within a text field before a user starts typing. If placeholder text is no longer visible after a user clicks into the field, users will no longer have that text available when they need to review their entries. (People who have cognitive or visual disabilities have additional problems with placeholder text.)

--- a/src/_components/form/textarea.md
+++ b/src/_components/form/textarea.md
@@ -1,0 +1,45 @@
+---
+layout: component
+permalink: /components/form/textarea
+has-parent: /components/form/
+title: Textarea
+intro-text: "Textarea allows people to enter any type of text."
+research-title: Form controls
+sketch-link: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/04A043C5-65CA-43BB-88F2-E17EF8B12D7D
+status: use-deployed
+anchors:
+  - anchor: Text area
+  - anchor: Usage
+  - anchor: How to use
+  - anchor: Code usage
+  - anchor: Accessibility considerations
+web-component: va-textarea
+---
+
+## Textarea
+
+{% include storybook-preview.html height="300px" story="components-va-textarea--default" link_text="va-textarea" %}
+
+## Usage
+
+### When to use textarea
+
+- If you can’t reasonably predict a user’s answer to a prompt and there might be wide variability in users’ answers.
+- When using another type of input will make answering more difficult. For example, birthdays and other known dates are easier to type in than they are to select from a calendar picker.
+- When users want to be able to paste in a response.
+
+### When to consider something else
+
+- When users are choosing from a specific set of options.
+
+### How to use 
+
+- Only show error validation messages or stylings after a user has interacted with a particular field.
+- Avoid using placeholder text that appears within a text field before a user starts typing. If placeholder text is no longer visible after a user clicks into the field, users will no longer have that text available when they need to review their entries. (People who have cognitive or visual disabilities have additional problems with placeholder text.)
+
+{% include component-docs.html component_name=page.web-component %}
+
+## Accessibility considerations
+
+- Avoid `placeholder` text for accessibility reasons. Most browsers’ default rendering of placeholder text does not provide a high enough contrast ratio.
+- Avoid breaking numbers with distinct sections (such as phone numbers, Social Security Numbers, or credit card numbers) into separate input fields. For example, use one input for phone number, not three (one for area code, one for local code, and one for number). Each field needs to be labeled for a screen reader and the labels for fields broken into segments are often not meaningful.

--- a/src/_components/form/textarea.md
+++ b/src/_components/form/textarea.md
@@ -8,7 +8,7 @@ research-title: Form controls
 sketch-link: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/04A043C5-65CA-43BB-88F2-E17EF8B12D7D
 status: use-deployed
 anchors:
-  - anchor: Text area
+  - anchor: Textarea
   - anchor: Usage
   - anchor: How to use
   - anchor: Code usage


### PR DESCRIPTION
## Description
Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/40157

[Related PR](https://github.com/department-of-veterans-affairs/component-library/pull/432)

This PR splits Textarea into its own subpage under Forms. 
Other text inputs page changes were done to use the singular noun now that textarea has its own page.

## Screenshots
<img width="1199" alt="Screen Shot 2022-05-18 at 16 33 46" src="https://user-images.githubusercontent.com/36863582/169150903-618af62b-7126-49c4-8e27-163893b3170f.png">
