### PR TITLE
Revert "Recommend telephone web component"

### DIFF
--- a/src/_content-style-guide/dates-and-numbers.md
+++ b/src/_content-style-guide/dates-and-numbers.md
@@ -93,14 +93,9 @@ Use hyphens between numbers, and don't use parentheses to set off the area code:
 
 - Use "select" to indicate the menu option after dialing a phone number.
 
-Hyperlink all phone numbers, including TTY numbers. Use the following Design System component for 508 accessibility and consistent formatting:
+Hyperlink all phone numbers, including TTY numbers. Use the following source code for 508 accessibility:
 
-<div class="site-showcase">
-  {% include_relative html/telephone.html %}
-</div>
-{% include snippet.html content='html/telephone.html' %}
-
-The `<va-telephone>` component currently doesn't support the "TTY" text inside of the clickable portion of the link, so for those numbers use the following markup:
+- `<a href="tel:+18008271000" aria-label="8 0 0. 8 2 7. 1 0 0 0.">800-827-1000</a>`
 
 - `<a href="tel:711" aria-label="TTY. 7 1 1.">TTY: 711</a>`. 
 

--- a/src/_content-style-guide/html/telephone.html
+++ b/src/_content-style-guide/html/telephone.html
@@ -1,9 +1,0 @@
-<p>
-  This is a telephone number: <va-telephone contact="8008271000"/>
-</p>
-<p>
-  This is a telephone number for international use: <va-telephone international contact="8008271000"/>
-</p>
-<p>
-  This is a telephone number with an extension: <va-telephone extension="123" contact="8008271000"/>
-</p>


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-design-system-documentation#893

Reverting for now since the `<va-telephone>` web component is not available for use inside Drupal yet ([see Slack convo here](https://dsva.slack.com/archives/C01DBGX4P45/p1653316713861639))

I have reached out to the CMS team to see about adding the `<va-telephone>` web component to the list of elements allowed in Drupal. There is a ticket for that work, but it may be a couple of months before they can complete it ([see Slack convo here](https://dsva.slack.com/archives/CT4GZBM8F/p1653319471617409)).