### PR TITLE
Update Divider page and Storybook links

### DIFF
--- a/src/_components/button/index.md
+++ b/src/_components/button/index.md
@@ -23,7 +23,7 @@ Examples of primary buttons:
 - Buttons that submit or save
 - Buttons that prompt users to sign in 
 
-{% include storybook-preview.html story="omponents-buttons-button--primary" %}
+{% include storybook-preview.html story="components-buttons-button--primary" %}
 
 ### Secondary button
 
@@ -34,19 +34,19 @@ Examples of secondary buttons:
 * Buttons that advance form pages 
 * Buttons for editing cards
 
-{% include storybook-preview.html story="omponents-buttons-button--secondary" %}
+{% include storybook-preview.html story="components-buttons-button--secondary" %}
 
 ### Big buttons
 
 Any button can be made bigger by adding a class name of `usa-button-big` to the button.
 
-{% include storybook-preview.html story="omponents-buttons-button--big" %}
+{% include storybook-preview.html story="components-buttons-button--big" %}
 
 ### Disabled buttons
 
 Only `<button>` elements can be disabled with a `disabled` attribute. To make a `<a>` element disabled, you must use `.usa-button.usa-button-disabled` on the element.
 
-{% include storybook-preview.html story="omponents-buttons-button--disabled" %}
+{% include storybook-preview.html story="components-buttons-button--disabled" %}
 
 ## Usage
 

--- a/src/_components/button/index.md
+++ b/src/_components/button/index.md
@@ -23,7 +23,7 @@ Examples of primary buttons:
 - Buttons that submit or save
 - Buttons that prompt users to sign in 
 
-{% include storybook-preview.html story="components-buttons--primary" %}
+{% include storybook-preview.html story="omponents-buttons-button--primary" %}
 
 ### Secondary button
 
@@ -34,19 +34,19 @@ Examples of secondary buttons:
 * Buttons that advance form pages 
 * Buttons for editing cards
 
-{% include storybook-preview.html story="components-buttons--secondary" %}
+{% include storybook-preview.html story="omponents-buttons-button--secondary" %}
 
 ### Big buttons
 
 Any button can be made bigger by adding a class name of `usa-button-big` to the button.
 
-{% include storybook-preview.html story="components-buttons--big" %}
+{% include storybook-preview.html story="omponents-buttons-button--big" %}
 
 ### Disabled buttons
 
 Only `<button>` elements can be disabled with a `disabled` attribute. To make a `<a>` element disabled, you must use `.usa-button.usa-button-disabled` on the element.
 
-{% include storybook-preview.html story="components-buttons--disabled" %}
+{% include storybook-preview.html story="omponents-buttons-button--disabled" %}
 
 ## Usage
 

--- a/src/_components/divider.md
+++ b/src/_components/divider.md
@@ -1,7 +1,7 @@
 ---
 layout: component
 title: Divider
-research-title: "Horizontal rules"
+research-title: "Divider"
 status: use-best-practice
 intro-text: "Dividers are used sparingly to separate significant sections of content"
 ---
@@ -10,16 +10,16 @@ intro-text: "Dividers are used sparingly to separate significant sections of con
 
 ### Stars
 
-{% include storybook-preview.html story="components-horizontal-rules--default-story" %}
+{% include storybook-preview.html story="components-divider--default-story" %}
 
 ## Usage
 
-### When to use horizontal rules
+### When to use divider
 
 - To signify a change in topic, content type, or expected interaction.
-- To create visual separation between chunks of content. Horizontal rules can help users distinguish between blocks of similar content at-a-glace.  
+- To create visual separation between chunks of content. Divider can help users distinguish between blocks of similar content at-a-glace.  
 
 ### When to consider something else
 
-- Avoid using horizontal rules between short, individual items that are in close proximity with one another, _unless_ they are separating navigation links. Consider using white space or headers instead to create vertical separation.  
+- Avoid using divider between short, individual items that are in close proximity with one another, _unless_ they are separating navigation links. Consider using white space or headers instead to create vertical separation.  
 - Use a background color box or card to separate a chunk of interactive elements, like search controls, from a list of search results. 

--- a/src/_components/tag.md
+++ b/src/_components/tag.md
@@ -11,7 +11,7 @@ anchors:
 
 ## Examples
 
-{% include storybook-preview.html height="50px" story="components-labels--default-story" %}
+{% include storybook-preview.html height="50px" story="components-tag--default-story" %}
 
 ## Usage
 


### PR DESCRIPTION
This PR updates the links for buttons, divider (previously named horizontal rules), and tag (previously named labels) as part of the changes [here](https://github.com/department-of-veterans-affairs/component-library/pull/437).