### PR TITLE
Fix "Last updated" date

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,14 @@
 name: Deploy site
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
 
 jobs:
   deploy:
     strategy:
       matrix:
-        environment: [{ bucket: dev-design.va.gov, config: dev.yml }]
+        environment: [{ bucket: dev-design.va.gov, config: dev.yml }, { bucket: staging-design.va.gov, config: staging.yml }, { bucket: design.va.gov, config: prod.yml }]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,14 @@
 name: Deploy site
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
 
 jobs:
   deploy:
     strategy:
       matrix:
-        environment: [{ bucket: dev-design.va.gov, config: dev.yml }, { bucket: staging-design.va.gov, config: staging.yml }, { bucket: design.va.gov, config: prod.yml }]
+        environment: [{ bucket: dev-design.va.gov, config: dev.yml }]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Use Node.js 14.x
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
## Description

We noticed recently that the "Last updated" text near the bottom of pages shows the date of the last deploy:

![Foundation index page showing last updated date of June 2, 2022](https://user-images.githubusercontent.com/2008881/171928519-ce78d96b-4b09-4da3-8d1a-e5a64718cc70.png)

This defect was introduced with https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/793. By changing the checkout action to [include the full git history](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches) we get the expected date:

![Dev environment with this fix showing last updated date of May 25, 2022](https://user-images.githubusercontent.com/2008881/171928917-b3460acf-0a63-43cc-a8a8-faeb165f8190.png)

This matches the repo history:

![Tooltip for Foundation index page in repo showing last modified date of May 25th](https://user-images.githubusercontent.com/2008881/171929419-8154aee8-1b82-4a35-ba68-506195c3a6fa.png)


