### PR TITLE
Add textarea to what's new page

### DIFF
--- a/src/_about/whats-new.md
+++ b/src/_about/whats-new.md
@@ -9,6 +9,12 @@ title: What’s new?
   The latest news and updates on the Design System, Forms library and the Content style guide.
 </div>
 
+### June 27, 2022
+
+**Design System updates**
+
+- [Textarea web component](https://design.va.gov/components/form/textarea)
+
 ### June 15, 2022
 
 - The va-button-primary utility class has been deprecated. Please visit the [Button component page](https://design.va.gov/components/button/) for guidance on buttons.


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/40176

This adds `<va-textara>` to the "What's new" page.