### PR TITLE
Add tty telephone example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,22 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
-      "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@department-of-veterans-affairs/component-library": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-11.0.0.tgz",
-      "integrity": "sha512-RQg3BG4Qnaj3QBuUSNQalGBTtNx8DrGV0ktF4xRdqsVFCBjmpvhWL0mOlanNXD0075ETWSlIKQXnlt4heV9RWQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-11.2.0.tgz",
+      "integrity": "sha512-AZWfFEaf7wBXpaB378T96JyBZRqlGwlvkT1EV3KcTkdEPdtmgZzEDAEX0QGpkw2ZzXTMGlj7D3L01i3gEEuX5g==",
       "dev": true,
       "requires": {
         "@department-of-veterans-affairs/react-components": "7.0.0",
-        "@department-of-veterans-affairs/web-components": "4.7.0",
+        "@department-of-veterans-affairs/web-components": "4.9.0",
         "i18next": "^21.6.14",
         "i18next-browser-languagedetector": "^6.1.4",
         "react-focus-on": "^3.5.1",
@@ -52,9 +52,9 @@
       }
     },
     "@department-of-veterans-affairs/web-components": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.7.0.tgz",
-      "integrity": "sha512-ef3bbOqctcfBXiATvvXPAOsZR7G7sazvARGFH4z1dHUzOEtoOB0KxwfmYZcYTmhGTg3twAOfEdGsjTmON0kNDQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.9.0.tgz",
+      "integrity": "sha512-E42aJBn+COfkptTzIXgQciHaee/t4vtUgJBoGk9VVoQ++/dykoCmWkOKt4vrAv3rjN9iKAz2XxitNBH4+8K9XQ==",
       "dev": true,
       "requires": {
         "@stencil/core": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/department-of-veterans-affairs/vets-design-system-documentation#readme",
   "devDependencies": {
-    "@department-of-veterans-affairs/component-library": "^11.0.0",
+    "@department-of-veterans-affairs/component-library": "^11.2.0",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-rename": "^2.0.0",

--- a/src/_components/telephone.md
+++ b/src/_components/telephone.md
@@ -42,6 +42,10 @@ The `va-telephone` component also follows the guidelines set for <a href="{{ sit
 
 {% include storybook-preview.html story="components-va-telephone--aria-described-by" height="80px" %}
 
+### TTY
+
+{% include storybook-preview.html story="components-va-telephone--tty" height="80px" %}
+
 ### Vanity Number
 
 {% include storybook-preview.html story="components-va-telephone--vanity-number" height="80px" %}
@@ -60,6 +64,7 @@ The `va-telephone` component also follows the guidelines set for <a href="{{ sit
 
 - Add a 3 or 10 digit phone number to the component to have it formatted correctly for usage in a page.
 - If the phone number should have an `extension`, be `non-clickable`, or represent an `international` number, additional props can be added to accommodate.
+- For TTY numbers, pass the `tty` boolean prop to have appropriate indicators in the link text and the `aria-label`.
 
 {% include component-docs.html component_name=page.web-component %}
 


### PR DESCRIPTION
I opened #1072 while I was trying to work on this. This is a followup to https://github.com/department-of-veterans-affairs/component-library/pull/492#pullrequestreview-1051350575

![Screenshot of the telephone component page, with the TTY storybook example highlighted as well as the new usage bullet point](https://user-images.githubusercontent.com/2008881/181140429-dea9f3ff-5238-4b8a-9375-5aeb2162c2ef.png)

![Screenshot of the props table from the telephone documentation page showing the information for the new `tty` prop. It is a boolean, defaults to false, and says "Indicates if this is a number meant to be called from a teletypewriter for deaf users."](https://user-images.githubusercontent.com/2008881/181140609-cba8e466-7541-467d-ba92-ea11805bb101.png)
