### PR TITLE
hide invalid expandable alert types

### DIFF
--- a/src/_components/alert-expandable.md
+++ b/src/_components/alert-expandable.md
@@ -26,13 +26,13 @@ Used to warn a user, such as when there are negative consequences, and when some
 
 {% include storybook-preview.html story="components-va-alert-expandable--warning" link_text="va-alert-expandable" %}
 
-### Success alert
+<!-- ### Success alert
 
 Used to indicate success.
 
-{% include storybook-preview.html story="components-va-alert-expandable--success" link_text="va-alert-expandable" %}
+{% include storybook-preview.html story="components-va-alert-expandable--success" link_text="va-alert-expandable" %} -->
 
-### Error alert
+<!-- ### Error alert
 
 Used when there is a problem or something destructive is about to occur.
 
@@ -40,7 +40,7 @@ Used when there is a problem or something destructive is about to occur.
 
 ### Continue alert
 
-{% include storybook-preview.html story="components-va-alert-expandable--continue" link_text="va-alert-expandable" %}
+{% include storybook-preview.html story="components-va-alert-expandable--continue" link_text="va-alert-expandable" %} -->
 
 ### No icon alerts
 


### PR DESCRIPTION
We would like to encourage teams to only use the info and warning variations of the expandable alert, at least for now. This PR just comments out the other variations for now. We can uncomment or delete them later based on future discussions.