### PR TITLE
Update Final Review and Development issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/DST-component_development.md
+++ b/.github/ISSUE_TEMPLATE/DST-component_development.md
@@ -34,9 +34,11 @@ If this is a pattern or component that is already in existence, check the Design
     - If this is a new component that has not gone through Staging Review, it should be labeled "Use with Caution: Candidate"
 - [ ] Merge component
 - [ ] Create a new release of component-library
-- [ ] Update component-library dependency in vets-design-system-documentation to have the updated component-docs.json
+- [ ] Update component-library dependency in vets-design-system-documentation to get the updated component-docs.json
+- [ ] Add analytics set-up to `vets-website` repository. See [guidance here](https://vfs.atlassian.net/wiki/spaces/DST/pages/2079817745/Component+development+process#Analytics%5BinlineExtension%5D).
 
 ## Acceptance Criteria
 - [ ] Component is written and added to Storybook
 - [ ] Component has had accessibility and design reviews
 - [ ] Design.va.gov has the latest version of component-library
+- [ ] Analytics has been configured for the component in the `vets-website` repo

--- a/.github/ISSUE_TEMPLATE/DST-component_final_review.md
+++ b/.github/ISSUE_TEMPLATE/DST-component_final_review.md
@@ -27,28 +27,20 @@ Once the Staging Review is complete and any issues have been addressed, announce
     - Link to component in Storybook:
 - [ ] Component is represented in the Design System Sketch Library
     - Link to component page in Sketch Library:
-- [ ] Component has passed an accessibility check
-    - Accessibility check ticket:
 
-### Slack announcement
-In the Slack announcement, please add links to the component page on design.va.gov and to the Design System Maturity Scale page on design.va.gov. Post the announcement in the following Slack channels:
-- #vfs-all-teams
-- #design
-- #cms-team
-- #platform-design-system
+### Announcement
+Add an item to the monthly [What's New update Confluence page](https://vfs.atlassian.net/wiki/spaces/DST/pages/2301100061/Monthly+DS+Updates+to+What+s+New) that says the Link web component is ready for use. It should include a link to the component on design.va.gov.
 
 Sample announcement:
-> :loudspeaker: The new [[component name] component](link to component on design.va.gov) is now available in the Design System! Guidance and design resources are now available on design.va.gov, in Storybook, and in the Sketch Pattern Library.
->
-> If you need any assistance using this component in your applications, please reach out to the Design System Team in the #vfs-platform-support channel.
+> The new [[component name] component](link to component on design.va.gov) is now available in the Design System. Guidance and design resources are now available on design.va.gov, in Storybook, and in the Sketch Pattern Library.
 
 ## Tasks
 - [ ] Fill out checklist above
 - [ ] Once all items are checked off, alert Carol that component is ready for staging review
 - [ ] Address any staging review comments
-- [ ] Announce component in Slack and add to "What's new"
+- [ ] Add announcement to "What's New" Confluence page for the month
 
 ## Acceptance Criteria
 - [ ] All items on the checklist are checked off and links have been added
 - [ ] Any comments from the staging review have been addressed
-- [ ] Component has been announced and added to "What's new"
+- [ ] Component announcement has been added to the "What's New Confluence page for the month


### PR DESCRIPTION
- add details about What's New Confluence page to Final Review issue template
- add task and AC for analytics to Development issue template