### PR TITLE
add Carol to external issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_template.md
+++ b/.github/ISSUE_TEMPLATE/1_bug_template.md
@@ -3,6 +3,7 @@ name: "1. \U0001F534 Bug report"
 about: Something in the Design System is not working as expected
 title: ''
 labels: 'vsp-design-system-team'
+assignees: 'caw310'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/2_documentation_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/2_documentation_request_form.yml
@@ -1,6 +1,7 @@
 name: 2. 📖 Documentation request form
 description: Suggest an update to documentation
 labels: ["vsp-design-system-team"]
+assignees: 'caw310'
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/3_experimental_design_request.md
+++ b/.github/ISSUE_TEMPLATE/3_experimental_design_request.md
@@ -3,6 +3,7 @@ name: "3. Experimental design system request"
 about: Propose an idea for a new component or pattern
 title: "Experimental Design [component or pattern name]"
 labels: vsp-design-system-team, experimental_design
+assignees: 'caw310'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/4_support_question.md
+++ b/.github/ISSUE_TEMPLATE/4_support_question.md
@@ -3,6 +3,7 @@ name: "4. \U0001F64B Support question"
 about: If you need support using the Design System
 title: ''
 labels: 'vsp-design-system-team'
+assignees: 'caw310'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/DST-component_development.md
+++ b/.github/ISSUE_TEMPLATE/DST-component_development.md
@@ -2,7 +2,9 @@
 name: "DST - Component development"
 about: INTERNAL DST USE ONLY
 title: "[component name] - Development"
-labels: vsp-design-system-team
+labels:
+    - vsp-design-system-team
+    - dst-engineering
 
 ---
 


### PR DESCRIPTION
Carol requested that she be added back as an assignee on the external issue templates. I also added the `dst-engineering` label to the component development issue template.