### PR TITLE
Fixes maturity level indicator in sidenav for sub-pages. [Amends #1255]

### DIFF
--- a/src/_components/form/date-input.md
+++ b/src/_components/form/date-input.md
@@ -2,7 +2,7 @@
 layout: component
 permalink: /components/form/date-input
 has-parent: /components/form/
-title: Date Input
+title: Date input
 research-title: Form controls
 intro-text: "Use the date input component to help users enter a date they would know or a date they can approximate."
 status: use-deployed

--- a/src/_components/form/memorable-date.md
+++ b/src/_components/form/memorable-date.md
@@ -2,7 +2,7 @@
 layout: component
 permalink: /components/form/memorable-date
 has-parent: /components/form/
-title: Memorable Date
+title: Memorable date
 research-title: Memorable Date
 intro-text: "Three text fields are the easiest way for users to enter most dates."
 status: use-with-caution-available

--- a/src/_components/form/radio-button.md
+++ b/src/_components/form/radio-button.md
@@ -2,7 +2,7 @@
 layout: component
 permalink: /components/form/radio-button
 has-parent: /components/form/
-title: Radio Button
+title: Radio button
 research-title: Form controls
 intro-text: "Radio buttons allow users to see all available choices at once and select exactly one option."
 status: use-deployed

--- a/src/_components/link/index.md
+++ b/src/_components/link/index.md
@@ -9,7 +9,7 @@ status: use-deployed
 sub-pages:
   - sub-page: Action
   - sub-page: Collection
-  - sub-page: Deep Content
+  - sub-page: Deep content
 anchors:
   - anchor: Examples
   - anchor: Usage

--- a/src/_includes/_side-nav.html
+++ b/src/_includes/_side-nav.html
@@ -27,11 +27,11 @@
                       <button class="usa-accordion-button" aria-expanded="{%- if open-accordion == true -%}true{%- else -%}false{%- endif -%}" aria-controls="{{p.title | slugify }}">{{p.title}}</button>
                       <div id="{{ slug }}" class="usa-accordion-content" aria-hidden="{%- if open-accordion == true -%}false{%- else -%}true{%- endif -%}">
                         <ul class="usa-sidenav-list">
-                          <li class="{% if is-current == true %}active-level{%- endif -%}">
+                          <li {% if is-current == true %}class="active-level"{%- endif -%}>
                             <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{site.baseurl}}{{ p.url }}">
                               {% if p.inner-title %}{{ p.inner-title }}{% else %}{{ p.title }}{%- endif -%}
                               {%- if p.status -%}
-                                {%- include _site-side-nav-status.html component=slug -%}
+                                {%- include _site-side-nav-status.html components=sortedPages component=p.title -%}
                               {%- endif -%}
                             </a>
                           </li>
@@ -46,7 +46,9 @@
                           <li>
                             <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{p.permalink }}{{ item.sub-page | slugify }}">
                               {{ item.sub-page }}
-                              {%- include _site-side-nav-status.html component=slug -%}
+                              {%- if include.name == 'components' -%}
+                                {%- include _site-side-nav-status.html components=sortedPages component=item.sub-page parent=p.title -%}
+                            {%- endif -%}
                             </a>
                           </li>
                           {% endfor %}
@@ -55,10 +57,10 @@
                     </li>
                   </ul>
                   {%- else -%}
-                  <li class="{% if is-current == true %}active-level{%- endif -%}">
+                  <li {% if is-current == true %}class="active-level"{%- endif -%}>
                     <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{site.baseurl}}{{ p.url }}">
                       {{p.title}}
-                      {%- include _site-side-nav-status.html component=slug -%}
+                      {%- include _site-side-nav-status.html components=sortedPages component=p.title -%}
                     </a>
                   </li>
                 {%- endif -%}

--- a/src/_includes/_side-nav.html
+++ b/src/_includes/_side-nav.html
@@ -20,34 +20,33 @@
         {% if p.layout != "iframe" %}
           {% unless p.index or p.has-parent %}
             {% unless p.draft and (p.url != page.url) %}
+                {% assign slug = p.title | slugify %}
                 {%- if p.sub-pages -%}
                   <ul class="usa-accordion">
                     <li>
                       <button class="usa-accordion-button" aria-expanded="{%- if open-accordion == true -%}true{%- else -%}false{%- endif -%}" aria-controls="{{p.title | slugify }}">{{p.title}}</button>
-                      <div id="{{p.title | slugify }}" class="usa-accordion-content" aria-hidden="{%- if open-accordion == true -%}false{%- else -%}true{%- endif -%}">
+                      <div id="{{ slug }}" class="usa-accordion-content" aria-hidden="{%- if open-accordion == true -%}false{%- else -%}true{%- endif -%}">
                         <ul class="usa-sidenav-list">
                           <li class="{% if is-current == true %}active-level{%- endif -%}">
                             <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{site.baseurl}}{{ p.url }}">
                               {% if p.inner-title %}{{ p.inner-title }}{% else %}{{ p.title }}{%- endif -%}
-                              {%- if p.status and (p.layout != "iframe") -%}
-                                {%- include _site-side-nav-status.html component-status=p.status -%}
+                              {%- if p.status -%}
+                                {%- include _site-side-nav-status.html component=slug -%}
                               {%- endif -%}
                             </a>
                           </li>
-                          {% for item in p.sub-pages%}
-                          {% assign link = page.url %}
-                          {% assign slug = item.sub-page | slugify %}
-                          {% if link contains slug %}
-                            {% assign is-current = true %}
-                          {% else %}
-                            {% assign is-current = false %}
-                          {% endif %}
+                          {% for item in p.sub-pages %}
+                            {% assign link = page.url %}
+                            {% assign slug = item.sub-page | slugify %}
+                            {% if link contains slug %}
+                              {% assign is-current = true %}
+                            {% else %}
+                              {% assign is-current = false %}
+                            {% endif %}
                           <li>
                             <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{p.permalink }}{{ item.sub-page | slugify }}">
                               {{ item.sub-page }}
-                            {%- if p.status and (p.layout != "iframe") -%}
-                              {%- include _site-side-nav-status.html component-status=p.status -%}
-                            {%- endif -%}
+                              {%- include _site-side-nav-status.html component=slug -%}
                             </a>
                           </li>
                           {% endfor %}
@@ -59,9 +58,7 @@
                   <li class="{% if is-current == true %}active-level{%- endif -%}">
                     <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{site.baseurl}}{{ p.url }}">
                       {{p.title}}
-                      {%- if p.status and (p.layout != "iframe") -%}
-                        {%- include _site-side-nav-status.html component-status=p.status -%}
-                      {%- endif -%}
+                      {%- include _site-side-nav-status.html component=slug -%}
                     </a>
                   </li>
                 {%- endif -%}

--- a/src/_includes/_site-side-nav-status.html
+++ b/src/_includes/_site-side-nav-status.html
@@ -1,22 +1,18 @@
-{% assign component_name = 'va-' | append: include.component %}
-{% assign component = site.data.component-docs.components | find: 'tag', component_name %}
+{% assign component_title = include.component %}
+{% assign component = include.components | where: "title", component_title | first %}
+
+{% if component == nil %}
+  {% assign component_title = include.parent | append: ' - ' | append: component_title  %}
+  {% assign component = include.components | where: "title", component_title | first %}
+{% endif %}
+
 {% if component %}
-  {% assign maturity_category = component.docsTags | where_exp: 'item', 'item.name == "maturityCategory"' | map: 'text' | first %}
-  {% assign maturity_level = component.docsTags | where_exp: 'item', 'item.name == "maturityLevel"' | map: 'text' | first %}
-
-  {% if maturity_category == 'caution' %}
-    {% assign maturity_category = 'use-with-caution' %}
-  {% endif %}
-
-  {% if maturity_level == 'best_practice' %}
-    {% assign maturity_level = 'best-practice' %}
-  {% endif %}
-
-  {% assign component_status = maturity_category | append: '-' | append: maturity_level %}
-
-  {% for scale in site.data.maturity-scale.scale %}
-    {%- if scale.name == component_status -%}
-    <i class="fas {{scale.symbol}} site-sidenav-status site-sidenav-status--{{component_status}}" aria-label="{{ scale.category }} {{ scale.title }}"></i>
-    {%- endif -%}
-  {% endfor %}
+  {% assign component_status = component.status %}
+  {% if component_status %}
+    {% for scale in site.data.maturity-scale.scale %}
+      {%- if scale.name == component_status -%}
+      <i class="fas {{scale.symbol}} site-sidenav-status site-sidenav-status--{{component_status}}" aria-label="{{ scale.category }} {{ scale.title }}"></i>
+      {%- endif -%}
+    {% endfor %}
+  {%- endif -%}
 {%- endif -%}

--- a/src/_includes/_site-side-nav-status.html
+++ b/src/_includes/_site-side-nav-status.html
@@ -1,5 +1,22 @@
-{% for scale in site.data.maturity-scale.scale %}
-  {%- if scale.name == include.component-status -%}
-  <i class="fas {{scale.symbol}} site-sidenav-status site-sidenav-status--{{include.component-status}}" aria-label="{{ scale.category }} {{ scale.title }}"></i>
-  {%- endif -%}
-{% endfor %}
+{% assign component_name = 'va-' | append: include.component %}
+{% assign component = site.data.component-docs.components | find: 'tag', component_name %}
+{% if component %}
+  {% assign maturity_category = component.docsTags | where_exp: 'item', 'item.name == "maturityCategory"' | map: 'text' | first %}
+  {% assign maturity_level = component.docsTags | where_exp: 'item', 'item.name == "maturityLevel"' | map: 'text' | first %}
+
+  {% if maturity_category == 'caution' %}
+    {% assign maturity_category = 'use-with-caution' %}
+  {% endif %}
+
+  {% if maturity_level == 'best_practice' %}
+    {% assign maturity_level = 'best-practice' %}
+  {% endif %}
+
+  {% assign component_status = maturity_category | append: '-' | append: maturity_level %}
+
+  {% for scale in site.data.maturity-scale.scale %}
+    {%- if scale.name == component_status -%}
+    <i class="fas {{scale.symbol}} site-sidenav-status site-sidenav-status--{{component_status}}" aria-label="{{ scale.category }} {{ scale.title }}"></i>
+    {%- endif -%}
+  {% endfor %}
+{%- endif -%}


### PR DESCRIPTION
I wanted to share this to show my work and to demonstrate how using the component-docs.json file is just not going to work for a number of reasons. Thus I'm going to have to refactor this to use the front matter in Jekyll instead. Here are the problems:

1. Maturity naming. We took some liberties in the naming of the maturityCateogry and maturityLevel. For example, "caution" instead of "use-with-caution" and "best_practice" instead of "best-practice". This isn't so hard to overcome and I did so in this code but, it's annoying.
2. Component naming. We also are inconsistent here and thus trying to take the title of the page and using slugify and append to come up with the component name is not working for some components. 
  * Sometimes it is just an abbreviation of the full title: "Radio button" is just "va-radio", "Date input" is "va-date", etc. 
  * Other times it is because of the way I re-wrote the titles: "Banner - Promo" is "var-promo-banner", "Progress bar - Segmented" is "va-segmented-progress-bar".
4. Components that are not web-components. We actually have a fair number of items that are not web-components yet:
  * Address block
  * MaintenanceBanner
  * Card
  * Divider
  * Form > Input message
  * Form > Label
  * Link > Action link
  * Link > Collection
  * Link > Deep Content
  * Sidenav
  * Tabs
  * Tag
  
Thus for now Jekyll front-matter is going to be the source of truth for maturity status until we can resolve this issues.