### PR TITLE
Bump component-library to 13.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,22 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@department-of-veterans-affairs/component-library": {
-      "version": "11.6.2",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-11.6.2.tgz",
-      "integrity": "sha512-/DWFmhNJHQw91t9wKITjdqOTeTX4qWboLZmqDhdPOTaYN/xUUqu9d5vLDnKnLjDmaVc9TJwLuNjqywmuYFI9Kw==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-13.4.0.tgz",
+      "integrity": "sha512-bl8OyqOYLwOsXGRsEo6Raxxz7gtZwMG/QSJdO90ofiyzJbmViUsWnTnSTVAER0oMRX10+wF/FK9oWLWJ2XxwbA==",
       "dev": true,
       "requires": {
-        "@department-of-veterans-affairs/react-components": "7.0.1",
-        "@department-of-veterans-affairs/web-components": "4.13.2",
+        "@department-of-veterans-affairs/react-components": "8.0.0",
+        "@department-of-veterans-affairs/web-components": "4.20.0",
         "i18next": "^21.6.14",
         "i18next-browser-languagedetector": "^6.1.4",
         "react-focus-on": "^3.5.1",
@@ -39,9 +39,9 @@
       }
     },
     "@department-of-veterans-affairs/react-components": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/react-components/-/react-components-7.0.1.tgz",
-      "integrity": "sha512-Z67ikFe45v7WCuALOVi8EFPSu9snYRcMLza2uEV9X+xzSNZmohcMwrWBYtiPAxcgBq2KC75SzbZFB2Crr6pa/Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/react-components/-/react-components-8.0.0.tgz",
+      "integrity": "sha512-WaJePVNQAVRgjn8gHZotHaRd58Irds0LCEEVyWLVuPNbTxXAlRvG7LSh8VkYsD2rlvF4Zsz1cBlgJ7DI71NtDQ==",
       "dev": true,
       "requires": {
         "classnames": "^2.2.6",
@@ -52,12 +52,12 @@
       }
     },
     "@department-of-veterans-affairs/web-components": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.13.2.tgz",
-      "integrity": "sha512-bpZYG7QzhXrLsSZcWw7NY67QtqfrjnB8TjWUIRI4DgrCaXF7lamRrFFI/zntP0SKEDENlpaiHS09ut6y4dSuyw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.20.0.tgz",
+      "integrity": "sha512-QG/4RVogd4tleIH0jWTRluAjVrl/24Rtlrp40sYKmmexFfPYyuG71JDYll/7NyEnlmaPQllsjyA/Yn0/Zv6cHw==",
       "dev": true,
       "requires": {
-        "@stencil/core": "^2.10.0",
+        "@stencil/core": "^2.19.2",
         "aria-hidden": "^1.1.3",
         "body-scroll-lock": "^4.0.0-beta.0",
         "classnames": "^2.3.1",
@@ -70,9 +70,9 @@
       "integrity": "sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg=="
     },
     "@stencil/core": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.4.tgz",
-      "integrity": "sha512-SGRlHpjV1RyFvzw6jFMVKpLNox9Eds3VvpbpD2SW9CuxdLonHDSFtQks5zmT4zs1Rse9I6kFc2mFK/dHNTalkg==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
+      "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw==",
       "dev": true
     },
     "ansi-colors": {
@@ -160,9 +160,9 @@
       "dev": true
     },
     "aria-hidden": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.1.tgz",
-      "integrity": "sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.2.tgz",
+      "integrity": "sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.0"
@@ -561,6 +561,17 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "chownr": {
@@ -593,9 +604,9 @@
       }
     },
     "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
       "dev": true
     },
     "cliui": {
@@ -1254,9 +1265,9 @@
       }
     },
     "focus-lock": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.2.tgz",
-      "integrity": "sha512-pZ2bO++NWLHhiKkgP1bEXHhR1/OjVcSvlCJ98aNJDFeb7H5OOQaO+SKOZle6041O9rv2tmbrO4JzClAvDUHf0g==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.4.tgz",
+      "integrity": "sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
@@ -1365,27 +1376,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
-      "dev": true,
-      "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
-      }
-    },
     "glob-stream": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
@@ -1405,13 +1395,12 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "^4.0.1"
           }
         },
         "is-glob": {
@@ -1673,21 +1662,21 @@
       "dev": true
     },
     "i18next": {
-      "version": "21.9.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.9.1.tgz",
-      "integrity": "sha512-ITbDrAjbRR73spZAiu6+ex5WNlHRr1mY+acDi2ioTHuUiviJqSz269Le1xHAf0QaQ6GgIHResUhQNcxGwa/PhA==",
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.17.2"
       }
     },
     "i18next-browser-languagedetector": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.5.tgz",
-      "integrity": "sha512-11t7b39oKeZe4uyMxLSPnfw28BCPNLZgUk7zyufex0zKXZ+Bv+JnmJgoB+IfQLZwDt1d71PM8vwBX1NCgliY3g==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-6.1.8.tgz",
+      "integrity": "sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.18.9"
+        "@babel/runtime": "^7.19.0"
       }
     },
     "inflight": {
@@ -2479,12 +2468,6 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
-      "dev": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2664,9 +2647,9 @@
       }
     },
     "react-focus-lock": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.1.tgz",
-      "integrity": "sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.2.tgz",
+      "integrity": "sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -2678,14 +2661,14 @@
       }
     },
     "react-focus-on": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.6.0.tgz",
-      "integrity": "sha512-onIRjpd9trAUenXNdDcvjc8KJUSklty4X/Gr7hAm/MzM7ekSF2pg9D8KBKL7ipige22IAPxLRRf/EmJji9KD6Q==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.7.0.tgz",
+      "integrity": "sha512-TsCnbJr4qjqFatJ4U1N8qGSZH+FUzxJ5mJ5ta7TY2YnDmUbGGmcvZMTZgGjQ1fl6vlztsMyg6YyZlPAeeIhEUg==",
       "dev": true,
       "requires": {
-        "aria-hidden": "^1.1.3",
-        "react-focus-lock": "^2.9.0",
-        "react-remove-scroll": "^2.5.2",
+        "aria-hidden": "^1.2.2",
+        "react-focus-lock": "^2.9.2",
+        "react-remove-scroll": "^2.5.5",
         "react-style-singleton": "^2.2.0",
         "tslib": "^2.3.1",
         "use-callback-ref": "^1.3.0",
@@ -2712,9 +2695,9 @@
       }
     },
     "react-remove-scroll-bar": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.3.tgz",
-      "integrity": "sha512-i9GMNWwpz8XpUpQ6QlevUtFjHGqnPG4Hxs+wlIJntu/xcsZVEpJcIV71K3ZkqNy2q3GfgvkD7y6t/Sv8ofYSbw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
       "dev": true,
       "requires": {
         "react-style-singleton": "^2.2.1",
@@ -2843,9 +2826,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "regex-not": {
@@ -3429,9 +3412,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "type": {
@@ -3697,7 +3680,7 @@
     "warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/department-of-veterans-affairs/vets-design-system-documentation#readme",
   "devDependencies": {
-    "@department-of-veterans-affairs/component-library": "^11.6.2",
+    "@department-of-veterans-affairs/component-library": "^13.4.0",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-rename": "^2.0.0",


### PR DESCRIPTION
## Description

Related to https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1298

Now that we have published a version of the `component-library` with the doc changes, we can update the documentation site to be consistent with storybook:

![image](https://user-images.githubusercontent.com/2008881/205986974-3dd15fd7-ea9a-4ca2-96b5-2b29337653a9.png)

This is to get an updated prop description for the telephone component's contact prop. The change was made available in [version `13.3.0`](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v13.3.0)

## Before

![image](https://user-images.githubusercontent.com/2008881/205986716-5431d78f-bec9-4f86-8d3f-58e91d2905de.png)

## After

![image](https://user-images.githubusercontent.com/2008881/205986841-a04d1ebc-753c-4b4f-8f13-1c4b7c6d194b.png)



