### PR TITLE
Bump component-library to 13.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,22 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
-      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
     },
     "@department-of-veterans-affairs/component-library": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-13.4.0.tgz",
-      "integrity": "sha512-bl8OyqOYLwOsXGRsEo6Raxxz7gtZwMG/QSJdO90ofiyzJbmViUsWnTnSTVAER0oMRX10+wF/FK9oWLWJ2XxwbA==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-13.6.0.tgz",
+      "integrity": "sha512-mKsA5H1ArYVj6SawydPbSaLyE7R8LHeE/uip58H4ZT1YGH3A5t3sbllCk+bcV3zgruFDwgMGsseyA31qRBcdjg==",
       "dev": true,
       "requires": {
         "@department-of-veterans-affairs/react-components": "8.0.0",
-        "@department-of-veterans-affairs/web-components": "4.20.0",
+        "@department-of-veterans-affairs/web-components": "4.22.0",
         "i18next": "^21.6.14",
         "i18next-browser-languagedetector": "^6.1.4",
         "react-focus-on": "^3.5.1",
@@ -52,9 +52,9 @@
       }
     },
     "@department-of-veterans-affairs/web-components": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.20.0.tgz",
-      "integrity": "sha512-QG/4RVogd4tleIH0jWTRluAjVrl/24Rtlrp40sYKmmexFfPYyuG71JDYll/7NyEnlmaPQllsjyA/Yn0/Zv6cHw==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.22.0.tgz",
+      "integrity": "sha512-z75pkGP0ffRq7PD3yauN43r+7OerXKNZFNSx1/4IUoqcFLATgrx0pOW6b1MXSEBz5bLoepg0QNQqXVMmFAdLjw==",
       "dev": true,
       "requires": {
         "@stencil/core": "^2.19.2",
@@ -1401,13 +1401,23 @@
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
           }
         },
         "is-glob": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -1848,8 +1858,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/department-of-veterans-affairs/vets-design-system-documentation#readme",
   "devDependencies": {
-    "@department-of-veterans-affairs/component-library": "^13.4.0",
+    "@department-of-veterans-affairs/component-library": "^13.6.0",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-rename": "^2.0.0",


### PR DESCRIPTION
With the addition of the v3 variation to [va-radio](https://design.va.gov/storybook/?path=/docs/uswds-va-radio--default) and [va-text-input](https://design.va.gov/storybook/?path=/docs/uswds-va-text-input--default) as well as [`hint` prop](https://github.com/department-of-veterans-affairs/component-library/pull/592) added to multiple form components, this will update the documentation site to be consistent with Storybook.

https://github.com/department-of-veterans-affairs/component-library/releases/tag/v13.6.0


![Screenshot 2022-12-22 at 12 44 31 PM](https://user-images.githubusercontent.com/872479/209205183-307f1a3f-d6df-4053-824b-08775655ed78.png)

![Screenshot 2022-12-22 at 12 45 27 PM](https://user-images.githubusercontent.com/872479/209205179-06109df5-867d-4b07-905f-3d60fac8f81e.png)
