### PR TITLE
Update component-library to latest version 13.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,22 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
     },
     "@department-of-veterans-affairs/component-library": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-13.6.0.tgz",
-      "integrity": "sha512-mKsA5H1ArYVj6SawydPbSaLyE7R8LHeE/uip58H4ZT1YGH3A5t3sbllCk+bcV3zgruFDwgMGsseyA31qRBcdjg==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-13.9.0.tgz",
+      "integrity": "sha512-x47XEPW87BvHR7Xr7uobOuTtTwqE/2XhI8NuQdHz3+QbqqR3phO6W6FINcRCLUvGHn4rC5NCQUCzLJH28JpAzA==",
       "dev": true,
       "requires": {
         "@department-of-veterans-affairs/react-components": "8.0.0",
-        "@department-of-veterans-affairs/web-components": "4.22.0",
+        "@department-of-veterans-affairs/web-components": "4.25.0",
         "i18next": "^21.6.14",
         "i18next-browser-languagedetector": "^6.1.4",
         "react-focus-on": "^3.5.1",
@@ -52,9 +52,9 @@
       }
     },
     "@department-of-veterans-affairs/web-components": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.22.0.tgz",
-      "integrity": "sha512-z75pkGP0ffRq7PD3yauN43r+7OerXKNZFNSx1/4IUoqcFLATgrx0pOW6b1MXSEBz5bLoepg0QNQqXVMmFAdLjw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.25.0.tgz",
+      "integrity": "sha512-aLqBu9AtCFrtOozYkgiJROFu+QqgQZxqrj/TDRTlIAcS7AUH6etm5ARP5PIzb6Q7RMNxvFHMn6a0C9zrmALoNA==",
       "dev": true,
       "requires": {
         "@stencil/core": "^2.19.2",
@@ -70,9 +70,9 @@
       "integrity": "sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg=="
     },
     "@stencil/core": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
-      "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.2.tgz",
+      "integrity": "sha512-r+vbxsGNcBaV1VDOYW25lv4QfXTlNoIb5GpUX7rZ+cr59yqYCZC5tlV+IzX6YgHKW62ulCc9M3RYtTfHtNbNNw==",
       "dev": true
     },
     "ansi-colors": {
@@ -1265,9 +1265,9 @@
       }
     },
     "focus-lock": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.4.tgz",
-      "integrity": "sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.5.tgz",
+      "integrity": "sha512-1mTr6pl9HBpJ8CqY7hRc38MCrcuTZIeYAkBD1gBTzbx5/to+bRBaBYtJ68iDq7ryTzAAbKrG3dVKjkrWTaaEaw==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
@@ -2656,13 +2656,13 @@
       }
     },
     "react-focus-lock": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.2.tgz",
-      "integrity": "sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.3.tgz",
+      "integrity": "sha512-cGNkz9p5Fpqio6hBHlkKxzRYrBYtcPosFOL6Q3N/LSbHjwP/PTBqHpvbgaOYoE7rWfzw8qXPKTB3Tk/VPgw4NQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.2",
+        "focus-lock": "^0.11.5",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
         "use-callback-ref": "^1.3.0",
@@ -3421,9 +3421,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
     "type": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/department-of-veterans-affairs/vets-design-system-documentation#readme",
   "devDependencies": {
-    "@department-of-veterans-affairs/component-library": "^13.6.0",
+    "@department-of-veterans-affairs/component-library": "^13.9.0",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-rename": "^2.0.0",


### PR DESCRIPTION
Latest version release notes: https://github.com/department-of-veterans-affairs/component-library/releases/tag/v13.9.0

Verified that this repo ran locally with the packages updated:

![Screenshot 2023-02-02 at 9 03 35 AM](https://user-images.githubusercontent.com/872479/216361004-84a777d7-b738-436c-9975-caad541d56a8.png)

![Screenshot 2023-02-02 at 9 03 26 AM](https://user-images.githubusercontent.com/872479/216361013-e0eda2d0-298d-4b23-a0a3-c22718f7a846.png)

![Screenshot 2023-02-02 at 9 04 42 AM](https://user-images.githubusercontent.com/872479/216361177-1a6e65d5-a316-49ed-99bc-da0def0d0b47.png)

