### PR TITLE
Update web component migration docs

### DIFF
--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -110,8 +110,8 @@ The Design System Team has specific linting and migration rules in place to help
 ## How to migrate to Web Components
 
 The Design System Team provides three ways to migrate specific React Components over to Web Components:
-* **Manual** - There are too many changes to automate and a guide will need to be followed.
-* **ESLint Rule** - In the `vets-website` repo there is a ESLint rule that informs you of the ability to convert from a React Component to a Web Component.
+* **Manual** - There is an ESLint rule that informs you that the React component is deprecated but there are too many changes to automate and a guide will need to be followed.
+* **ESLint Rule** - There is an ESLint rule that informs you of the ability to convert from a React Component to a Web Component with a migration click.
 * [**Migration Script**](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/component-migration/README.md) - There is a script available to be used in the CLI when in the `vets-website` repo to convert the React Component to a Web Component.
 
 ### Web component migrations
@@ -124,18 +124,20 @@ Here is a list of each Web Component and the migration available:
 * `va-alert-expandable`: N/A
 * `va-back-to-top`: N/A
 * `va-banner`: [Manual Migration](https://vfs.atlassian.net/wiki/spaces/DST/pages/2051080448/Liquid+template+migration+guidance#va-banner)
-* `va-breadcrumbs`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/eslint-plugin/lib/rules/prefer-web-component-library.js#L418)
+* `va-breadcrumbs`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
 * `va-button`: N/A
 * `va-checkbox`: N/A
 * `va-checkbox-group`: N/A
 * `va-date`: [Manual Migration](https://vfs.atlassian.net/wiki/spaces/DST/pages/2127527996/Manual+Component+Migration+Guide#Date-or-SimpleDate-to-va-date%3A)
 * `va-date-text-input`: N/A
 * `va-featured-content`: N/A
+* `va-file-input`: N/A
 * `va-loading-indicator`: [Migration Script](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/component-migration/transformers/loadingindicator.js)
-* `va-modal`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js#L421)
+* `va-modal`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
 * `va-number-input`: N/A
 * `va-on-this-page`: N/A
-* `va-pagination`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js#L424)
+* `va-omb-info`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
+* `va-pagination`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
 * `va-process-list`: [Manual Migration](https://vfs.atlassian.net/wiki/spaces/DST/pages/2051080448/Liquid+template+migration+guidance#va-process-list)
 * `va-progress-bar`: N/A
 * `va-promo-banner`: [Manual Migration](https://vfs.atlassian.net/wiki/spaces/DST/pages/2051080448/Liquid+template+migration+guidance#va-promo-banner)
@@ -143,7 +145,7 @@ Here is a list of each Web Component and the migration available:
 * `va-search-input`: N/A
 * `va-segmented-progress-bar`: N/A
 * `va-select`: N/A
-* `va-table`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js#L427)
-* `va-telephone`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js#L430)
-* `va-text-input`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js#L433)
+* `va-table`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
+* `va-telephone`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
+* `va-text-input`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
 * `va-textarea`: N/A

--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -110,9 +110,11 @@ The Design System Team has specific linting and migration rules in place to help
 ## How to migrate to Web Components
 
 The Design System Team provides three ways to migrate specific React Components over to Web Components:
-* **Manual** - There is an ESLint rule that informs you that the React component is deprecated but there are too many changes to automate and a guide will need to be followed.
+* **Manual** - There is an ESLint rule that informs you that the React component is deprecated but there are too many changes to automate a replacement and a guide will need to be followed ([Storybook](https://design.va.gov/storybook/?path=/story/about-introduction--page) example, Confluence documentation, or other guidance within the ESLint popup).
 * **ESLint Rule** - There is an ESLint rule that informs you of the ability to convert from a React Component to a Web Component with a migration click.
 * [**Migration Script**](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/component-migration/README.md) - There is a script available to be used in the CLI when in the `vets-website` repo to convert the React Component to a Web Component.
+
+Auto-migrations may not be able to perfectly migrate every component. Before you merge your PR be sure to inspect the diff and test thoroughly. Migrations also do not update test files so you will need to update those manually.
 
 ### Web component migrations
 


### PR DESCRIPTION
This adds the `va-omb-info` and `va-file-input` components to the list and also adds more clarity around the types of migration options available.

There is more detail about why I've updated the description for some of these migration types in the ticket comment here: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1692#issuecomment-1535074604

![Screenshot 2023-05-04 at 9 08 59 AM](https://user-images.githubusercontent.com/872479/236232927-b9e10fbe-de8e-41f5-aa32-77150733005e.png)
