### PR TITLE
Remove trailing slash from links that cause a 403 forbidden errors

### DIFF
--- a/src/_components/card.md
+++ b/src/_components/card.md
@@ -68,7 +68,7 @@ You can see these options in use in the [variations](#variations) below.
 ### When to consider something else
 
 * **Eligibility information or other content highlight.** The [Featured content]({{ site.baseurl }}/components/featured-content) component, which is the only card-like element represented in Drupal, is meant to act as a content highlight for the most important information on the page. It was originally intended to highlight eligibility information. Featured content is not a Card and they should not be used interchangeably.
-* **Dynamic content.** Do not use a Card when inserting content into the page in response to a user action. In those cases use a variation of an [Alert]({{ site.baseurl }}/components/alert/) component.
+* **Dynamic content.** Do not use a Card when inserting content into the page in response to a user action. In those cases use a variation of an [Alert]({{ site.baseurl }}/components/alert) component.
 * **Forms - A Card is not a Fieldset.** A fieldset can be used to cluster related form fields into a sub-section of a form. The visual design of a fieldset should not mimic a Card. 
 * **Large data - A Card is not a Table row.** A collection of cards does not scale up to large data sets. If users needs to compare large amounts of data consider a [table]({{ self.baseurl }}/components/table).
 * **Navigation - A Card is not a Button or a Link.** While a Card may contain a call-to-action link, and may itself be a link, it is not solely a navigation element. Do not use a Card to act as a large tap target. 

--- a/src/_patterns/help-users-to/complete-a-sub-task.md
+++ b/src/_patterns/help-users-to/complete-a-sub-task.md
@@ -109,7 +109,7 @@ This pattern can be implemented with standard form elements and other optional c
 * [Accordion]({{ site.baseurl }}/components/accordion)
 * [Alert]({{ site.baseurl }}/components/alert)
 * [Button pair]({{ site.baseurl }}/components/button/button-pair)
-* [Link - Action]({{ site.baseurl }}/components/link/action/)
+* [Link - Action]({{ site.baseurl }}/components/link/action)
 
 ## Content considerations
 


### PR DESCRIPTION
There were a couple of links that were causing a 403 error page to display. Removing the trailing backslash seems to fix it:

 
<img width="829" alt="Screenshot 2023-05-18 at 3 26 12 PM" src="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/e2aed54e-3fb5-4b2b-88b6-41b7bbb7d71e">

<img width="803" alt="Screenshot 2023-05-18 at 3 26 21 PM" src="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/184cef53-06ed-4604-a158-fe4d8d9d4bd2">

