### PR TITLE
Update web component usage docs

### DIFF
--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -6,11 +6,11 @@ has-parent: /about/developers/
 intro-text: Web Components are a set of web platform APIs that allow you to create new custom, reusable, encapsulated HTML tags to use in web pages and web apps. 
 anchors:
   - anchor: How to use a web component
+  - anchor: React and Web Components
   - anchor: Vanilla JavaScript applications
   - anchor: React applications
   - anchor: Custom events
   - anchor: Native events
-  - anchor: React and Web Components
   - anchor: How to migrate to Web Components
 ---
 
@@ -27,6 +27,27 @@ A web component looks like an HTML element such as `<va-example-component>`. It 
   * You write HTML templates that you can add to your HTML elements
   * You add slots to provide additional context within the component
 
+## React and Web Components
+
+Use our VA Design System Web Components where applicable in your projects. We maintain this component library to provide VA teams with an ecosystem of vetted and tested components.
+
+While large portions of VA.gov are built via React applications, there are some teams that cannot import React directly into their projects and have to add work around hacks in order to use React components.
+
+Due to these issues the Design System Team recommends using our Web Components on VA.gov applications and pages.
+
+For easy identification, all of our Web Components begin with a `va-` prefix. For example, the Web Component version of our alert component is named `va-alert` (or `VaAlert` as the React binding).
+
+The benefits of using Design System Web Components include:
+
+- Web Components can be imported into any JS Framework
+- Consistent syntax across frameworks and projects
+- Actively updated and maintained - we are deprecating most React components and they will not have the latest updates
+- Performance and speed
+
+The Design System Team has specific linting and migration rules in place to help ease in the transition from React to Web Components. We also encourage all developers use Design System Components in their applications instead of creating their own similar components. 
+
+If our components do not meet your needs, we would love to hear about it. Reach out to us in Slack at #platform-design-system or [submit a bug report](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/new/choose). And if you are interested in contributing to the Design System, review [how to contribute a new component to the design system]({{ site.baseurl }}/about/developers/contributing).
+
 ## Vanilla JavaScript applications
 
 If a Design System web component will be used without the need for passing in a function, object, array, or custom event, you are ready to use it without any additional imports. 
@@ -34,6 +55,7 @@ If a Design System web component will be used without the need for passing in a 
 A vanilla web component is used like `<va-example-component>` (identified by tags prefixed with `<va-*>`).
 
 We make our best efforts to avoid creating web components with object or array properties in order to make them easier to use in static HTML pages.
+
 
 ## React applications
 
@@ -72,7 +94,7 @@ The equivalent vanilla Web Component version using `<va-example-component>` woul
 
 <hr>
 
-```jsx
+```html
 <script>
   const component = document.querySelector('va-example-component');
   const exampleFunction = () => { return "Hello, World!" };
@@ -110,7 +132,7 @@ If the Web Component has a custom event that you need to use and you're **not** 
 
 <hr>
 
-```js
+```html
 <script>
   const element = document.querySelector('va-example-component');
   const exampleCallback = event => { console.log(event.detail) }
@@ -131,46 +153,45 @@ Some of our web components utilize native HTML DOM events such as `click` and `b
 
 To **use native events in JSX**, they must be prefixed with `on` and use camel case. Given the native `blur` event, use `onBlur`.
 
+
 An example using the `click` event in JSX:
+
+<hr>
+
 ```jsx
-<va-button text="Edit" onClick={e => console.log(e)} />
+<va-button text="Edit" onClick={ (event) => console.log(event.detail) } />
 ```
+
+<hr>
 
 To **use native events in vanilla JavaScript**, they can be used inline and prefixed with `on` **or** by adding an event listener using the event name as the event type.
 
 An example using the `blur` event in vanilla JavaScript:
+
+<hr>
+
 ```js
 <va-button onblur="handleBlur()" />
 ```
 
+<hr>
+
 Another example using the `blur` event in vanilla JavaScript:
-```js
-const element = document.querySelector('va-button');
-element.addEventListener('blur', event => { /* your listener */ })
+
+<hr>
+
+```html
+<script>
+  const element = document.querySelector('va-button');
+  element.addEventListener('blur', (event) => { console.log(event.detail) })
+</script>
+
+<va-button>
 ```
 
+<hr>
+
 For more information about native events in a specific component, refer to the [Storybook documentation](https://design.va.gov/storybook/?path=/docs/about-introduction--page).
-
-## React and Web Components
-
-Use our VA Design System Web Components where applicable in your projects. We maintain this component library to provide VA teams with an ecosystem of vetted and tested components.
-
-While large portions of VA.gov are built via React applications, there are some teams that cannot import React directly into their projects and have to add work around hacks in order to use React components.
-
-Due to these issues the Design System Team recommends using our Web Components on VA.gov applications and pages.
-
-For easy identification, all of our Web Components begin with a `va-` prefix. For example, the Web Component version of our alert component is named `va-alert` (or `VaAlert` as the React binding).
-
-The benefits of using Design System Web Components include:
-
-- Web Components can be imported into any JS Framework
-- Consistent syntax across frameworks and projects
-- Actively updated and maintained - we are deprecating most React components and they will not have the latest updates
-- Performance and speed
-
-The Design System Team has specific linting and migration rules in place to help ease in the transition from React to Web Components. We also encourage all developers use Design System Components in their applications instead of creating their own similar components. 
-
-If our components do not meet your needs, we would love to hear about it. Reach out to us in Slack at #platform-design-system or [submit a bug report](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/new/choose). And if you are interested in contributing to the Design System, review [how to contribute a new component to the design system]({{ site.baseurl }}/about/developers/contributing).
 
 ## How to migrate to Web Components
 

--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -5,7 +5,7 @@ permalink: /about/developers/using-web-components
 has-parent: /about/developers/
 intro-text: Web Components are a set of web platform APIs that allow you to create new custom, reusable, encapsulated HTML tags to use in web pages and web apps. 
 anchors:
-  - anchor: How to create a web component
+  - anchor: How to use a web component
   - anchor: Vanilla JavaScript applications
   - anchor: React applications
   - anchor: Custom events
@@ -14,11 +14,11 @@ anchors:
   - anchor: How to migrate to Web Components
 ---
 
-## How to create a web component
+## How to use a web component
 
-We can create our new component called `<va-web-component>`, with its unique styling and functionality, and use it in any JavaScript framework or library. The fact that these components are framework agnostic, helps us future proof our component library.
+We can use a component called `<va-example-component>`, with its unique styling and functionality, in any JavaScript framework or library. The fact that these components are framework agnostic, helps us future proof our component library.
 
-Web Components consist of three parts:
+[Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) consist of three parts:
 * A custom HTML element
   * Where you register your own HTML tag
 * The shadow DOM
@@ -29,27 +29,42 @@ Web Components consist of three parts:
 
 ## Vanilla JavaScript applications
 
-If the Design System web components will be used in a vanilla JavaScript application, you are ready to use them (identified by tags prefixed with `<va-*>`).
+If the Design System web components will be used without the need for passing in a function, object, array, or custom event, you are ready to use them without any additional imports. 
+
+A vanilla web component is used like `<va-example-component>` (identified by tags prefixed with `<va-*>`).
 
 We make our best efforts to avoid creating web components with object or array properties in order to make them easier to use in static HTML pages.
 
 ## React applications
 
-If the Design System web components will be used in a React application, you are ready to use them unless:
+React application have an option of either using the web component directly like `<va-example-component>` or importing the React binding for the web component which would look like this `<VaExampleComponent>`. Both of these implementations render as web components though.
+
+**How to choose to use the vanilla component or React binding?** 
+
+If either of these are true, we would recommend using the React binding for ease of use:
 
 - You must pass in a function, object or array to a web component's properties
 - You must use custom events
 
-**If your use case is listed above, you will have to use our web component bindings for React.** If you are not sure if you need to use a custom event, please refer to the web component's Storybook documentation to see its events and properties.
+If you are not sure if you need to use a custom event, refer to the web component's [Storybook documentation](https://design.va.gov/storybook/?path=/docs/about-introduction--page) to review its events and properties.
 
-Bindings are component wrappers that allow our web components to work as first-class React components, allowing us to handle custom events and to pass in more than strings and numbers to a web component's properties. You will have to import each web component's bindings like you would with a React component.
+**Importing a React binding of a web component**
+
+Bindings are component wrappers that allow our web components to work as first-class React components. This allows them to handle custom events and to pass in more than primitives to a web component's properties. 
+
+Example of importing the React binding of a web component:
+
 ```jsx
-import { VaExampleComponent } from "@department-of-veterans-affairs/component-library/dist/react-bindings";
+import { 
+  VaExampleComponent 
+} from "@department-of-veterans-affairs/component-library/dist/react-bindings";
 
-const exampleFunction = () => console.log("Hello, World!");
+const exampleFunction = (event) => console.log(event.detail);
 
 <VaExampleComponent exampleProp={exampleFunction} />
 ```
+
+The equivalent vanilla web component version of this would be `<va-example-component>`.
 
 ## Custom Events
 
@@ -64,6 +79,8 @@ element.addEventListener('vaChange', event => { /* your listener */ })
 ```
 
 The majority of our web components also fire a `component-library-analytics` event used to translate component library actions into analytics data layer events. The event handler for this event exists in `vets-website`.
+
+For more information about custom events in a specific component, refer to the [Storybook documentation](https://design.va.gov/storybook/?path=/docs/about-introduction--page).
 
 ## Native Events
 
@@ -89,23 +106,28 @@ const element = document.querySelector('va-button');
 element.addEventListener('blur', event => { /* your listener */ })
 ```
 
+For more information about native events in a specific component, refer to the [Storybook documentation](https://design.va.gov/storybook/?path=/docs/about-introduction--page).
+
 ## React and Web Components
 
-**Note:** Please use our VA Design System Web Components where applicable in your projects. We maintain this component library to provide VA teams with an ecosystem of vetted and tested components.
+Use our VA Design System Web Components where applicable in your projects. We maintain this component library to provide VA teams with an ecosystem of vetted and tested components.
 
 While large portions of VA.gov are built via React applications, there are some teams that cannot import React directly into their projects and have to add work around hacks in order to use React components.
 
 Due to these issues the Design System Team recommends using our Web Components on VA.gov applications and pages.
 
-For easy identification, all of our Web Components begin with a `va-` prefix. For example, the Web Component version of our alert component is named `va-alert`.
+For easy identification, all of our Web Components begin with a `va-` prefix. For example, the Web Component version of our alert component is named `va-alert` (or `VaAlert` as the React binding).
 
-Benefits include:
-- Future proofing as Web Components can be imported into any JS Framework
+The benefits of using Design System Web Components include:
+
+- Web Components can be imported into any JS Framework
 - Consistent syntax across frameworks and projects
 - Actively updated and maintained - we are deprecating most React components and they will not have the latest updates
 - Performance and speed
 
-The Design System Team has specific linting and migration rules in place to help ease in the transition from React to Web Components. We also encourage all developers use Design System Components in their applications instead of creating their own similar components. If our components do not meet your needs, we would love to hear about it. Please reach out to us in Slack or [submit a bug report](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/new?assignees=caw310&labels=vsp-design-system-team&template=bug_template.md&title=). If you are interested, please review [how to contribute a new component to the design system]({{ site.baseurl }}/about/developers/contributing).
+The Design System Team has specific linting and migration rules in place to help ease in the transition from React to Web Components. We also encourage all developers use Design System Components in their applications instead of creating their own similar components. 
+
+If our components do not meet your needs, we would love to hear about it. Reach out to us in Slack or [submit a bug report](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/new/choose). And if you are interested in contributing to the Design System, review [how to contribute a new component to the design system]({{ site.baseurl }}/about/developers/contributing).
 
 ## How to migrate to Web Components
 

--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -68,7 +68,7 @@ const exampleFunction = () => { return "Hello, World!" };
 
 <hr>
 
-The equivalent vanilla web component version using `<va-example-component>` would be this:
+The equivalent vanilla Web Component version using `<va-example-component>` would be this:
 
 <hr>
 
@@ -84,29 +84,13 @@ The equivalent vanilla web component version using `<va-example-component>` woul
 
 <hr>
 
-It can be more convenient to use the React binding version of the web component in React when a function is needed to be passed into a prop. But if the Web Component does not require interaction like this, the vanilla web component can be used without needing an import.
+It can be more convenient to use the React binding version of the Web Component in React when a function is needed to be passed into a prop. But if the Web Component does not require interaction like this, the vanilla web component can be used without needing an import.
 
 ## Custom Events
 
-Some of the Design System web components allow for custom events.
+Some of the Design System Web Components allow for custom events.
 
-If you must use custom events and you're using React, you must prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
-
-If you must use custom events and you're **not** using React, you must add an event listener using the event name as the event type. Given an event named `vaChange`, use:
-
-<hr>
-```js
-<script>
-  const element = document.querySelector('va-example-component');
-  const exampleFunction = event => { console.log(event.detail) }
-  element.addEventListener('vaChange', exampleFunction)
-<script>
-
-<va-example-component>
-```
-<hr>
-
-The React binding equivalent of this would be:
+If the Web Components has a custom event that you need to use and you're using the React binding, you will need to prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
 
 <hr>
 
@@ -115,11 +99,27 @@ import {
   VaExampleComponent 
 } from "@department-of-veterans-affairs/component-library/dist/react-bindings";
 
-const exampleFunction = (event) => { console.log(event.detail) }
+const exampleCallback = (event) => { console.log(event.detail) }
 
-<VaExampleComponent exampleProp={exampleFunction} />
+<VaExampleComponent onVaChange={exampleCallback} />
 ```
+
 <hr>
+
+If the Web Components has a custom event that you need to use and you're **not** using the React binding, you will add an event listener using the event name as the event type:
+
+<hr>
+
+```js
+<script>
+  const element = document.querySelector('va-example-component');
+  const exampleCallback = event => { console.log(event.detail) }
+  element.addEventListener('vaChange', exampleCallback)
+<script>
+
+<va-example-component>
+```
+
 
 The majority of our web components also fire a `component-library-analytics` event used to send component library interactions into analytics data layer events. The [handler for the Google Analytics event](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/site-wide/component-library-analytics-setup.js) exists in vets-website.
 

--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -170,7 +170,7 @@ The benefits of using Design System Web Components include:
 
 The Design System Team has specific linting and migration rules in place to help ease in the transition from React to Web Components. We also encourage all developers use Design System Components in their applications instead of creating their own similar components. 
 
-If our components do not meet your needs, we would love to hear about it. Reach out to us in Slack or [submit a bug report](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/new/choose). And if you are interested in contributing to the Design System, review [how to contribute a new component to the design system]({{ site.baseurl }}/about/developers/contributing).
+If our components do not meet your needs, we would love to hear about it. Reach out to us in Slack at #platform-design-system or [submit a bug report](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/new/choose). And if you are interested in contributing to the Design System, review [how to contribute a new component to the design system]({{ site.baseurl }}/about/developers/contributing).
 
 ## How to migrate to Web Components
 

--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -84,13 +84,13 @@ The equivalent vanilla Web Component version using `<va-example-component>` woul
 
 <hr>
 
-It can be more convenient to use the React binding version of the Web Component in React when a function is needed to be passed into a prop. But if the Web Component does not require interaction like this, the vanilla web component can be used without needing an import.
+It can be more convenient to use the React binding version of the Web Component in React when a function is needed to be passed into a prop. But if you don't require passing in a function or listening to events, use the vanilla Web Component and avoid an import entirely.
 
 ## Custom Events
 
 Some of the Design System Web Components allow for custom events.
 
-If the Web Components has a custom event that you need to use and you're using the React binding, you will need to prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
+If the Web Component has a custom event that you need to use and you're using the React binding, you will need to prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
 
 <hr>
 
@@ -106,7 +106,7 @@ const exampleCallback = (event) => { console.log(event.detail) }
 
 <hr>
 
-If the Web Components has a custom event that you need to use and you're **not** using the React binding, you will add an event listener using the event name as the event type:
+If the Web Component has a custom event that you need to use and you're **not** using the React binding, you will add an event listener using the event name as the event type:
 
 <hr>
 

--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -16,7 +16,7 @@ anchors:
 
 ## How to use a web component
 
-We can use a component called `<va-example-component>`, with its unique styling and functionality, in any JavaScript framework or library. The fact that these components are framework agnostic, helps us future proof our component library.
+A web component looks like an HTML element such as `<va-example-component>`. It has unique styling and functionality and can work in any JavaScript framework or library. The fact that these components are framework agnostic, helps us future proof our component library.
 
 [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) consist of three parts:
 * A custom HTML element
@@ -29,7 +29,7 @@ We can use a component called `<va-example-component>`, with its unique styling 
 
 ## Vanilla JavaScript applications
 
-If the Design System web components will be used without the need for passing in a function, object, array, or custom event, you are ready to use them without any additional imports. 
+If a Design System web component will be used without the need for passing in a function, object, array, or custom event, you are ready to use it without any additional imports. 
 
 A vanilla web component is used like `<va-example-component>` (identified by tags prefixed with `<va-*>`).
 
@@ -46,7 +46,7 @@ If either of these are true, we would recommend using the React binding for ease
 - You must pass in a function, object or array to a web component's properties
 - You must use custom events
 
-If you are not sure if you need to use a custom event, refer to the web component's [Storybook documentation](https://design.va.gov/storybook/?path=/docs/about-introduction--page) to review its events and properties.
+If you are not sure if you need either of those features, refer to the web component's [Storybook documentation](https://design.va.gov/storybook/?path=/docs/about-introduction--page) to review its events and properties.
 
 **Importing a React binding of a web component**
 
@@ -54,33 +54,76 @@ Bindings are component wrappers that allow our web components to work as first-c
 
 Example of importing the React binding of a web component:
 
+<hr>
+
 ```jsx
 import { 
   VaExampleComponent 
 } from "@department-of-veterans-affairs/component-library/dist/react-bindings";
 
-const exampleFunction = (event) => console.log(event.detail);
+const exampleFunction = () => { return "Hello, World!" };
 
 <VaExampleComponent exampleProp={exampleFunction} />
 ```
 
-The equivalent vanilla web component version of this would be `<va-example-component>`.
+<hr>
+
+The equivalent vanilla web component version using `<va-example-component>` would be this:
+
+<hr>
+
+```jsx
+<script>
+  const component = document.querySelector('va-example-component');
+  const exampleFunction = () => { return "Hello, World!" };
+  component.exampleProp = exampleFunction();
+</script>
+
+<va-example-component />
+```
+
+<hr>
+
+It can be more convenient to use the React binding version of the web component in React when a function is needed to be passed into a prop. But if the Web Component does not require interaction like this, the vanilla web component can be used without needing an import.
 
 ## Custom Events
 
 Some of the Design System web components allow for custom events.
 
-If you must use custom events and you're using JSX, you must prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
+If you must use custom events and you're using React, you must prefix events with `on`. Given an event named `vaChange`, use `onVaChange`.
 
-If you must use custom events and you're **not** using JSX, you must add an event listener using the event name as the event type. Given an event named `vaChange`, use: 
+If you must use custom events and you're **not** using React, you must add an event listener using the event name as the event type. Given an event named `vaChange`, use:
+
+<hr>
 ```js
-const element = document.querySelector('va-example-component');
-element.addEventListener('vaChange', event => { /* your listener */ })
+<script>
+  const element = document.querySelector('va-example-component');
+  const exampleFunction = event => { console.log(event.detail) }
+  element.addEventListener('vaChange', exampleFunction)
+<script>
+
+<va-example-component>
 ```
+<hr>
 
-The majority of our web components also fire a `component-library-analytics` event used to translate component library actions into analytics data layer events. The event handler for this event exists in `vets-website`.
+The React binding equivalent of this would be:
 
-For more information about custom events in a specific component, refer to the [Storybook documentation](https://design.va.gov/storybook/?path=/docs/about-introduction--page).
+<hr>
+
+```jsx
+import { 
+  VaExampleComponent 
+} from "@department-of-veterans-affairs/component-library/dist/react-bindings";
+
+const exampleFunction = (event) => { console.log(event.detail) }
+
+<VaExampleComponent exampleProp={exampleFunction} />
+```
+<hr>
+
+The majority of our web components also fire a `component-library-analytics` event used to send component library interactions into analytics data layer events. The [handler for the Google Analytics event](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/site-wide/component-library-analytics-setup.js) exists in vets-website.
+
+For more information about custom events for specific components, refer to the [Storybook documentation](https://design.va.gov/storybook/?path=/docs/about-introduction--page).
 
 ## Native Events
 


### PR DESCRIPTION
These updates are for the `/about/developers/using-web-components` page to add a little more detail and context to help teams migrate their design system React components to Web Components. For example, how to implement either the react binding or the vanilla component:

![Screenshot 2023-05-23 at 12 25 33 PM](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/3d21f159-0174-4a37-a59e-a8a525afeaa3)

![Screenshot 2023-05-23 at 12 36 16 PM](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/de24a863-cbaa-43cb-bf11-8b4e58b17749)


Related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1608