### PR TITLE
Fixes and additions to developer contributing docs

### DIFF
--- a/src/_about/developers/contributing.md
+++ b/src/_about/developers/contributing.md
@@ -6,8 +6,8 @@ has-parent: /about/developers/
 intro-text: How to contribute code to the Design System.
 anchors:
   - anchor: Modifying existing components
-  - anchor: Writing CSS for the Design System
   - anchor: Contributing new components
+  - anchor: Timeline to get component to prod
 ---
 
 The two main ways for developers to contribute to the Design System are by modifying existing components and contributing new components. Regardless of which type of contribution you are making, each PR should:
@@ -28,7 +28,7 @@ PRs which make a change to the Design System should be manageable in size (less 
 
 ## Contributing new components
 
-This section details how to contribute new components. If you haven't read it already, refer to the [contributing to the design system]({{ site.baseurl }}/about/contributing-to-the-design-system) page for more information about the full process. If you're unsure if you're ready to start creating a new component, make sure you've gone through the experimental design process details]({{ site.baseurl }}/about/contributing-to-the-design-system) first.
+This section details how to contribute new components. If you haven't read it already, refer to the [contributing to the design system]({{ site.baseurl }}/about/contributing-to-the-design-system) page for more information about the full process. If you're unsure if you're ready to start creating a new component, make sure you've gone through the [experimental design process details]({{ site.baseurl }}/about/contributing-to-the-design-system) first.
 
 ### Writing your component
 
@@ -50,6 +50,30 @@ If your team needs to create a 'gizmo' component, you would create `packages/web
 
 Our web components are made using [Stencil](https://stenciljs.com/docs/introduction), which makes use of Typescript, JSX, and SCSS as part of its development tools. Stencil's documentation outlines and defines virtually everything you need to know to develop a Typescript-based component, so be sure to rely on that as you work.
 
+### Component front-matter
+
+Near the top of your component, you will want to include the component front-matter content in order to aid the automatic documentation generator. Here is an example from the `va-banner` component:
+
+```javascript
+/**
+ * @componentName Banner
+ * @maturityCategory use
+ * @maturityLevel deployed
+ */
+@Component({
+  tag: 'va-banner',
+  styleUrl: 'va-banner.css',
+  shadow: true,
+})
+```
+
+- `@componentName` should be the name of your component, minus the 'va-' prefix
+- `@maturityCategory` should be  `caution` based on the [maturity scale]({{ site.baseurl }}/about/maturity-scale)
+- `@maturityLevel` should be `candidate` based on the [maturity scale]({{ site.baseurl }}/about/maturity-scale)
+- `tag` should be the 'custom element tag' that the component will use when inserted into a page
+- `styleUrl` should point to the file Stencil should use as this component's stylesheet (see [Writing S(C)SS](#writing-scss-for-your-component) below for more details)
+- `shadow` should always be `true`, as we make use of the shadow DOM to encapsulate all components and prevent arbitrary DOM and style changes
+
 ### Writing (S)CSS for your component
 
 When writing style definitions for a component, it's useful to know that stylesheets are automatically encapsulated and scoped by Stencil into the component you're writing. That is, the styles defined in `va-gizmo.scss` will be automatically applied only to the component defined in `va-gizmo.tsx`.
@@ -70,3 +94,12 @@ label {
 
 ### Test coverage
 As with all code, test coverage is critical. This is especially true with shared code. Aim for at least 90% unit test coverage before declaring a component to be `stable`.
+
+## Timeline to get component to prod
+
+1. [Experimental design ]({{ site.baseurl }}/about/contributing-to-the-design-system)  is proposed and approved
+2. New component is created
+3. PR submitted, reviewed, revised, and approved
+4. New version of the component-library package is released
+5. PR to update the component-library package in vets-website is submitted, reviewed, and approved
+6. vets-website now has access to include the new component into apps


### PR DESCRIPTION
- Fixed a couple broken links and an incorrect anchor at the top of the page
- Added a "front-matter" definition section
- Added a "time to prod" timeline section

Closes #1717 