### PR TITLE
Manually add hydration class to web component for the form labels list

### DIFF
--- a/src/_includes/content/form-labels-masterlist.md
+++ b/src/_includes/content/form-labels-masterlist.md
@@ -1,95 +1,95 @@
-<va-accordion>
-  <va-accordion-item id="applicant-information">
+<va-accordion class="hydrated">
+  <va-accordion-item id="applicant-information" class="hydrated">
     <h6 slot="headline">
       Applicant information
     </h6>
     {% include content/labels/applicant-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="contact-information">
+  <va-accordion-item id="contact-information" class="hydrated">
     <h6 slot="headline">
       Contact information
     </h6>
     {% include content/labels/contact-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="military-address">
+  <va-accordion-item id="military-address" class="hydrated">
     <h6 slot="headline">
       Military address
     </h6>
     {% include content/labels/military-address.html %}
   </va-accordion-item>
-  <va-accordion-item id="marriage-information">
+  <va-accordion-item id="marriage-information" class="hydrated">
     <h6 slot="headline">
       Marriage information
     </h6>
     {% include content/labels/marriage-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="sponsor-information">
+  <va-accordion-item id="sponsor-information" class="hydrated">
     <h6 slot="headline">
       Sponsor information
     </h6>
     {% include content/labels/sponsor-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="caregiver-information">
+  <va-accordion-item id="caregiver-information" class="hydrated">
     <h6 slot="headline">
       Caregiver information
     </h6>
     {% include content/labels/caregiver-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="service-history">
+  <va-accordion-item id="service-history" class="hydrated">
     <h6 slot="headline">
       Service history
     </h6>
     {% include content/labels/service-history.html %}
   </va-accordion-item>
-  <va-accordion-item id="dependent-information">
+  <va-accordion-item id="dependent-information" class="hydrated">
     <h6 slot="headline">
       Dependent information
     </h6>
     {% include content/labels/dependent-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="income-information">
+  <va-accordion-item id="income-information" class="hydrated">
     <h6 slot="headline">
       Income information
     </h6>
     {% include content/labels/income-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="healthcare-information">
+  <va-accordion-item id="healthcare-information" class="hydrated">
     <h6 slot="headline">
       Health care information
     </h6>
     {% include content/labels/healthcare-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="education-information">
+  <va-accordion-item id="education-information" class="hydrated">
     <h6 slot="headline">
       Education information
     </h6>
     {% include content/labels/education-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="burial-information">
+  <va-accordion-item id="burial-information" class="hydrated">
     <h6 slot="headline">
       Burial information
     </h6>
     {% include content/labels/burial-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="disability-information">
+  <va-accordion-item id="disability-information" class="hydrated">
     <h6 slot="headline">
       Disability information
     </h6>
     {% include content/labels/disability-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="pension-information">
+  <va-accordion-item id="pension-information" class="hydrated">
     <h6 slot="headline">
       Pension information
     </h6>
     {% include content/labels/pension-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="housing-information">
+  <va-accordion-item id="housing-information" class="hydrated">
     <h6 slot="headline">
       Housing information
     </h6>
     {% include content/labels/housing-information.html %}
   </va-accordion-item>
-  <va-accordion-item id="review-and-submit-content">
+  <va-accordion-item id="review-and-submit-content" class="hydrated">
     <h6 slot="headline">
       Review and submit content
     </h6>


### PR DESCRIPTION
This is an attempt to temporarily fix the issue of `va-accordion` not displaying on the [form labels list page](https://design.va.gov/content-style-guide/form-labels#form-label-masterlist).

Previewed locally:

![Screenshot 2023-08-09 at 3 15 49 PM](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/891ca18e-388f-4838-bd72-6aa1365ebeec)
