### PR TITLE
Update index.md to add information about CAIA

### DIFF
--- a/src/_about/accessibility/index.md
+++ b/src/_about/accessibility/index.md
@@ -26,3 +26,9 @@ As part of staging reviews, new components must also complete [advanced testing 
 **Note:** The testing tools above may be replaced, depending on context, with NVDA and TalkBack.
 
 It is the intention of this team to improve our testing standards to more accurately reflect the full disabled experience. Today our compliance testing sets a minimal standard that we are striving to raise.
+
+## Get accessibility guidance early from the CAIA team
+
+The Sitewide Content, Accessibility, and Information Architecture (CAIA) team can help you meet VA.gov’s accessibility standards. Whether you’re starting a new product or refining an existing one, contact the CAIA team as early as possible to create accurate, consistent, accessible, and equitable content for Veterans.
+
+Submit a [Sitewide Content, Accessibility, and IA intake form ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=RLHecht%2C+coforma-terry%2C+kristinoletmuskat%2C+laurwill%2C+sara-amanda&labels=sitewide+CAIA%2C+sitewide+content-product+support%2C+Sitewide+IA%2C+sitewide+content%2C+sitewide+accessibility&projects=&template=sitewide-content-intake-form.md&title=%3CType+of+Request%3E+from+%3CTeam%3E) in GitHub to get started.


### PR DESCRIPTION
CAIA wants to help VFS teams "shift left" and consider a11y, content, and IA issues as early as possible in their development processes. One way we feel we can do this is to draw more awareness to the existence of CAIA, what we do, and how teams can contact us for help.

We'd like to add a snippet of information about CAIA to the Accessibility page on design.va.gov to raise awareness and encourage early communications.

I added a section about getting guidance from the CAIA team on the bottom of this page.