### PR TITLE
Remove va-telephone from the React migration list

### DIFF
--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -227,5 +227,4 @@ Here is a list of each Web Component and the migration available:
 * `va-omb-info`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
 * `va-process-list`: [Manual Migration](https://vfs.atlassian.net/wiki/spaces/DST/pages/2051080448/Liquid+template+migration+guidance#va-process-list)
 * `va-promo-banner`: [Manual Migration](https://vfs.atlassian.net/wiki/spaces/DST/pages/2051080448/Liquid+template+migration+guidance#va-promo-banner)
-* `va-telephone`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
 * `va-text-input`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)


### PR DESCRIPTION
Since the Telephone React component has been deprecated and all instances replaced with va-telephone, we can remove it from the [web component migrations list](https://design.va.gov/about/developers/using-web-components#web-component-migrations).

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1631

![Screenshot 2023-09-20 at 12 38 00 PM](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/18d6fe4e-04b0-43b1-aed4-bc40e96808ab)
