### PR TITLE
Remove va-checkbox from migration list

### DIFF
--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -220,7 +220,6 @@ Here is a list of each Web Component and the migration available:
 * `va-alert`: [Migration Script](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/component-migration/transformers/alertbox.js)
 * `va-breadcrumbs`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
 * `va-button`: [Manual Migration](https://design.va.gov/storybook/?path=/docs/components-va-button--primary)
-* `va-checkbox`: [Manual Migration](https://design.va.gov/storybook/?path=/docs/components-va-checkbox--default)
 * `va-file-input`: [Manual Migration](https://design.va.gov/storybook/?path=/docs/components-va-file-input--default)
 * `va-loading-indicator`: [Migration Script](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/component-migration/transformers/loadingindicator.js)
 * `va-modal`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/e37233f7ed059c91bf43e92f825390bbf5991298/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)


### PR DESCRIPTION
The React `Checkbox` component has been replaced with the `va-checkbox` and deprecated so this PR removes it from this migration list:

![Screenshot 2023-10-03 at 10 52 41 AM](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/29e9a2d7-3606-448c-9632-3867182251f2)


related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1920