### PR TITLE
Add component-library link to readme and adjust wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vets Design System Documentation
 
-This is repo for the design system documentation, aka [design.va.gov](https://design.va.gov). If you are looking for the repo that contains the CSS and Javascript for the components, see the [formation package](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/formation) inside the [veteran-facing-services-tools repo](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools).
+This repo is for VA Design System documentation, aka [design.va.gov](https://design.va.gov). If you are looking for the repo that contains the design system components, see the [component-library](https://github.com/department-of-veterans-affairs/component-library). Additionally, the [Formation package](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/formation) inside the [veteran-facing-services-tools repo](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools) contains sitewide VA.gov base styles and utility classes.
 
 Min specs:
 


### PR DESCRIPTION
I noticed that the README of this repo does not mention the component-library (only Formation) and it did not link to it. Also made some minor grammar/wording updates to that paragraph.