### PR TITLE
 Copy Storybook Assets to Root Directory using Gulp

### DIFF
--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -9,7 +9,7 @@ gulp.task('build',
       'images',
       'javascript',
       'css',
-      'storybook'
+      'storybook',
     )
 //  )
 );

--- a/config/gulp/build.js
+++ b/config/gulp/build.js
@@ -8,7 +8,8 @@ gulp.task('build',
       'fonts',
       'images',
       'javascript',
-      'css'
+      'css',
+      'storybook'
     )
 //  )
 );

--- a/config/gulp/storybook.js
+++ b/config/gulp/storybook.js
@@ -4,7 +4,7 @@ var task = 'storybook';
 gulp.task('move-assets', function (done) {
     console.log("Moving assets from storybook to root assets directory.");
 
-    var stream = gulp.src('./node_modules/@department-of-veterans-affairs/formation/dist/assets/*')
+    var stream = gulp.src('./node_modules/@department-of-veterans-affairs/web-components/dist/assets/*')
         .pipe(gulp.dest('assets'));
 
     return stream;

--- a/config/gulp/storybook.js
+++ b/config/gulp/storybook.js
@@ -1,10 +1,10 @@
 var gulp = require('gulp');
 
-gulp.task('move-assets', function () {
+gulp.task('storybook', function () {
     console.log("Moving assets from storybook to root assets directory.");
 
     return gulp.src('storybook/assets/**/*')
         .pipe(gulp.dest('assets/'));
 });
 
-gulp.task('default', gulp.parallel('move-assets'));
+gulp.task('default', gulp.parallel('storybook'));

--- a/config/gulp/storybook.js
+++ b/config/gulp/storybook.js
@@ -1,10 +1,13 @@
 var gulp = require('gulp');
+var task = 'storybook';
 
-gulp.task('storybook', function () {
+gulp.task('move-assets', function (done) {
     console.log("Moving assets from storybook to root assets directory.");
 
-    return gulp.src('storybook/assets/**/*')
-        .pipe(gulp.dest('assets/'));
+    var stream = gulp.src('./node_modules/@department-of-veterans-affairs/formation/dist/assets/*')
+        .pipe(gulp.dest('assets'));
+
+    return stream;
 });
 
-gulp.task('default', gulp.parallel('storybook'));
+gulp.task(task, gulp.parallel('move-assets'));

--- a/config/gulp/storybook.js
+++ b/config/gulp/storybook.js
@@ -1,0 +1,10 @@
+var gulp = require('gulp');
+
+gulp.task('move-assets', function () {
+    console.log("Moving assets from storybook to root assets directory.");
+
+    return gulp.src('storybook/assets/**/*')
+        .pipe(gulp.dest('assets/'));
+});
+
+gulp.task('default', gulp.parallel('move-assets'));

--- a/config/gulp/storybook.js
+++ b/config/gulp/storybook.js
@@ -5,7 +5,7 @@ gulp.task('move-assets', function (done) {
     console.log("Moving assets from storybook to root assets directory.");
 
     var stream = gulp.src('./node_modules/@department-of-veterans-affairs/web-components/dist/assets/*')
-        .pipe(gulp.dest('assets'));
+        .pipe(gulp.dest('./assets'));
 
     return stream;
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ require( './config/gulp/images' );
 require( './config/gulp/css' );
 require( './config/gulp/javascript' );
 require( './config/gulp/json' );
-require( './config/gulp/build' );
 require( './config/gulp/storybook' );
+require( './config/gulp/build' );
 
 var gulp = require( 'gulp' );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,5 +7,6 @@ require( './config/gulp/css' );
 require( './config/gulp/javascript' );
 require( './config/gulp/json' );
 require( './config/gulp/build' );
+require( './config/gulp/storybook' );
 
 var gulp = require( 'gulp' );


### PR DESCRIPTION
This PR introduces a new Gulp task that automates the process of copying assets from the `storybook/assets/ `directory to the root `assets/` directory. This ensures consistent asset paths across different environments, addressing the issue of assets not being found in the production environment.

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1977