### PR TITLE
Update index.md

### DIFF
--- a/src/_components/link/index.md
+++ b/src/_components/link/index.md
@@ -102,7 +102,7 @@ Review "[Usage](#usage)" for guidance.
 
 ## Content considerations
 
-Refer to the [Content Style Guide on Links]({{ site.baseurl }}/content-style-guide/links/).
+Refer to the [Content Style Guide on Links]({{ site.baseurl }}/content-style-guide/links).
 
 ## Accessibility considerations
 


### PR DESCRIPTION
https://design.va.gov/content-style-guide/links/ goes to a 403. Removed the trailing /