### PR TITLE
remove va-breadcrumb from migration list

### DIFF
--- a/src/_about/developers/using-web-components.md
+++ b/src/_about/developers/using-web-components.md
@@ -218,7 +218,6 @@ Here is a list of each Web Component and the migration available:
 
 * `va-accordion`: [Manual Migration](https://vfs.atlassian.net/wiki/spaces/DST/pages/2127527996/Manual+Component+Migration+Guide)
 * `va-alert`: [Migration Script](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/component-migration/transformers/alertbox.js)
-* `va-breadcrumbs`: [ESLint Rule](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/eslint-plugin/lib/rules/prefer-web-component-library.js)
 * `va-button`: [Manual Migration](https://design.va.gov/storybook/?path=/docs/components-va-button--primary)
 * `va-file-input`: [Manual Migration](https://design.va.gov/storybook/?path=/docs/components-va-file-input--default)
 * `va-loading-indicator`: [Migration Script](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/component-migration/transformers/loadingindicator.js)


### PR DESCRIPTION
This PR removes the `va-breadcrumbs` from the migration list as it has been replaced with the web component.

![Screenshot 2023-11-07 at 4 05 39 PM](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/22892911/f5405d78-a589-42bd-a270-abfb71e0512e)

closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1632