### PR TITLE
override formation background color classes

### DIFF
--- a/src/assets/stylesheets/application.scss
+++ b/src/assets/stylesheets/application.scss
@@ -111,3 +111,17 @@ font-matter: yay
   background: #16171F;
 }
 
+/*
+For the time being, we're manually overriding these two classes that get imported from Formation
+because they get dynamically generated in color-palette-example.html. This is necessary because 
+Formation still relies on the older --primary-darker/darkest naming convention for the sake of 
+backwards compatibility. When Formation has been fully deprecated and we are on new utility classes, 
+these can be removed along with an update to how classes are generated in color-palette-example.html. 
+*/
+.vads-u-background-color--primary-dark {
+  background-color: $color-primary-dark !important;
+}
+
+.vads-u-background-color--primary-darker {
+  background-color: $color-primary-darker !important;
+}


### PR DESCRIPTION
## Description 
This pull request adds two overrides to Formation background color utility classes. This is needed because Formation doesn't actually have a `vads-u-background-color--primary-dark`  class, and the `vads-u-background-color--primary-darker` class is used in vets-website and we want to keep the change isolated to the documentation repo for the time being. 

![Screenshot from 2023-12-11 09-26-59](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/15097156/04e6595a-ebdd-446a-a9e6-b55d0a683b26)
![Screenshot from 2023-12-11 09-27-38](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/15097156/3efc08fb-e69d-4709-bba8-a79fe7944f5f)
