### PR TITLE
Removing unused "examples" anchor on Multiple Responses pattern

### DIFF
--- a/src/_patterns/ask-users-for/multiple-responses.md
+++ b/src/_patterns/ask-users-for/multiple-responses.md
@@ -10,7 +10,6 @@ intro-text: "Choose the most appropriate implementation of this pattern in forms
 status: use-deployed
 anchors:
   - anchor: Usage
-  - anchor: Examples
   - anchor: How to design and build - Single page
   - anchor: How to design and build - Multi-page
   - anchor: How to design and build - Add item


### PR DESCRIPTION
there's no "examples" section in the page anymore, so the "examples" anchor link is broken https://dsva.slack.com/archives/C0NGDDXME/p1705943992084859?thread_ts=1705940075.543229&cid=C0NGDDXME