### PR TITLE
Update developer contribution documentation

### DIFF
--- a/src/_about/developers/contributing.md
+++ b/src/_about/developers/contributing.md
@@ -13,7 +13,7 @@ anchors:
 
 ## Getting started
 
-The [Component Library](https://github.com/department-of-veterans-affairs/component-library) is a monorepo that contains various Design System packages including a package for web components.
+The [Component Library](https://github.com/department-of-veterans-affairs/component-library) is a monorepo that contains various Design System packages including a package for web components and Storybook.
 
 To begin local development, clone the Component Library repo and follow the steps in the readme file for [Running the Build via Storybook](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#running-build-via-storybook). After following each of these steps, a local instance of Storybook will load at `localhost:6006` where development can occur.
 

--- a/src/_about/developers/contributing.md
+++ b/src/_about/developers/contributing.md
@@ -5,50 +5,78 @@ permalink: /about/developers/contributing
 has-parent: /about/developers/
 intro-text: How to contribute code to the Design System.
 anchors:
+  - anchor: Getting started
   - anchor: Modifying existing components
   - anchor: Contributing new components
-  - anchor: Timeline to get component to prod
+  - anchor: Timeline to get a new component to prod
 ---
 
-The two main ways for developers to contribute to the Design System are by modifying existing components and contributing new components. Regardless of which type of contribution you are making, each PR should:
+## Getting started
 
-- have at least 90% test coverage
-- have appropriate comments/documentation for functions, classes, etc.
-- have Storybook stories for new features
-- minimize complexity
-- include only the smallest changeset required for the feature or fix
+The [Component Library](https://github.com/department-of-veterans-affairs/component-library) is a monorepo that contains various Design System packages including a package for web components.
+
+To begin local development, clone the Component Library repo and follow the steps in the readme file for [Running the Build via Storybook](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#running-build-via-storybook). After following each of these steps, a local instance of Storybook will load at `localhost:6006` where development can occur.
+
+Other important sections to review:
+
+- [Branch Naming](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#branch-naming)
+- [How to choose a version number](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#how-to-choose-a-version-number)
+- [Testing](https://github.com/department-of-veterans-affairs/component-library?tab=readme-ov-file#testing)
+
+### Ways to contribute
+
+The two main ways for developers to contribute to the Design System are by modifying existing components (fixes, new features, enhancements) and contributing new components. 
+
+Regardless of which type of contribution you are making, each PR should:
+
+- Include or update tests where applicable
+- Have appropriate comments and documentation for functions, classes, logic, as well as descriptive pull requests
+- Have Storybook stories added or updated where applicable
+- Minimize complexity
+- Include only the smallest changeset required for the feature or fix
 
 ## Modifying existing components
 
-PRs which make a change to the Design System should be manageable in size (less than ~500 lines of code). This is to meant to:
+The Design System welcomes all pull requests that will help us improve the component library. This includes fixes for [existing issues](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues), issues that you've identified yourself, or enhancements. Thank you for your contribution!
+
+### General considerations
+
+PRs which make a change to the Design System should be manageable in size. This is meant to:
 
 - Save your time as the developer
 - Keep PRs tightly focused
-- Keep the review process short.
+- Keep the review process short
+
+Be sure to follow the steps outlined in the [Getting Started](/about/developers/contributing#getting-started) section above and submit your pull request when its ready. You can reach out to the #platform-design-system Slack channel with any other questions.
 
 ## Contributing new components
 
-This section details how to contribute new components. If you haven't read it already, refer to the [contributing to the design system]({{ site.baseurl }}/about/contributing-to-the-design-system) page for more information about the full process. If you're unsure if you're ready to start creating a new component, make sure you've gone through the [experimental design process details]({{ site.baseurl }}/about/contributing-to-the-design-system) first.
+This section details how to contribute new components. If you haven't read it already, refer to the [contributing to the design system]({{ site.baseurl }}/about/contributing-to-the-design-system) page for more information about the full process. If you're unsure if you're ready to start creating a new component, make sure you've gone through the [experimental design process details]({{ site.baseurl }}/about/contributing-to-the-design-system) first. 
 
-### Writing your component
+Reach out to the #platform-design-system Slack channel with any other questions.
+
+### General considerations
 
 Each component should:
 - Be absent of business logic and domain knowledge
 - Not import application code
 - Not introduce breaking changes
 
-Developing the component as if it had no dependencies on anything within the vets-website repo will make the code more reusable.
+Developing the component as if it had no dependencies on anything within the vets-website will make the code more reusable.
 
-### Code location
+### Creating a new component
 
-Each component is located in its own directory in the [`component-library`](https://github.com/department-of-veterans-affairs/component-library/tree/main/packages/web-components/src/components) at `packages/web-components/src/components/`.
+Each component is located in its own directory within the `web-components` package of the [`component-library`](https://github.com/department-of-veterans-affairs/component-library/tree/main/packages/web-components/src/components)
 
-**Example:**
-If your team needs to create a 'gizmo' component, you would create `packages/web-components/src/components/va-gizmo/va-gizmo.tsx` as the entry file for your component. Other necessary files, such as CSS/SCSS and any tests, would share the same file name but a different extension, for example `va-gizmo.scss`. Note that .css and .scss files are supported, but no other CSS preprocessor at this time. See the [va-accordion](https://github.com/department-of-veterans-affairs/component-library/tree/main/packages/web-components/src/components/va-accordion) component's folder for further examples of how to structure your code.
+The library leverages [Stencil](https://stenciljs.com/docs/introduction) for generating web components which makes use of Typescript, JSX, and CSS. Stencil's documentation outlines and defines virtually everything you need to know to develop a Stencil generated web component, so be sure to rely on that as you work.
 
-### Stencil
+To create a new component, run the Stencil interactive generator in the web-components package: 
 
-Our web components are made using [Stencil](https://stenciljs.com/docs/introduction), which makes use of Typescript, JSX, and SCSS as part of its development tools. Stencil's documentation outlines and defines virtually everything you need to know to develop a Typescript-based component, so be sure to rely on that as you work.
+`yarn stencil generate va-new-component`
+
+The generator will create files for your component in the `packages/web-components/src/components/` director to include a `.jsx` entry file as well as a stylesheet and testing files for your component.
+
+Additional Stencil documentation: [https://stenciljs.com/docs/cli#stencil-generate](https://stenciljs.com/docs/cli#stencil-generate)
 
 ### Component front-matter
 
@@ -68,36 +96,33 @@ Near the top of your component, you will want to include the component front-mat
 ```
 
 - `@componentName` should be the name of your component, minus the 'va-' prefix
-- `@maturityCategory` should be  `caution` based on the [maturity scale]({{ site.baseurl }}/about/maturity-scale)
-- `@maturityLevel` should be `candidate` based on the [maturity scale]({{ site.baseurl }}/about/maturity-scale)
+- `@maturityCategory` should be assigned based on the [maturity scale]({{ site.baseurl }}/about/maturity-scale) which for a new component should be `caution`
+- `@maturityLevel` should be assigned based on the [maturity scale]({{ site.baseurl }}/about/maturity-scale) which for a new component should be `candidate`
 - `tag` should be the 'custom element tag' that the component will use when inserted into a page
-- `styleUrl` should point to the file Stencil should use as this component's stylesheet (see [Writing S(C)SS](#writing-scss-for-your-component) below for more details)
-- `shadow` should always be `true`, as we make use of the shadow DOM to encapsulate all components and prevent arbitrary DOM and style changes
+- `styleUrl` should point to the file Stencil should use as this component's stylesheet
+- `shadow` should be `true`, as we make use of the shadow DOM to encapsulate all components and prevent arbitrary DOM and style changes
 
-### Writing (S)CSS for your component
+### Writing Style for your component
 
-When writing style definitions for a component, it's useful to know that stylesheets are automatically encapsulated and scoped by Stencil into the component you're writing. That is, the styles defined in `va-gizmo.scss` will be automatically applied only to the component defined in `va-gizmo.tsx`.
+Web component styles are scoped to the component's shadow dom which means that styles are encapsulated.
 
-Even so, it is frequently helpful to make use of the `:host` selector when defining your styles, especially in the context of 'legacy' styles that make use of the Formation (aka USWDS v1 + VA Design System) style library. To ensure your styles only apply to the old style framework while we transition to USWDS v3, use the `:host(:not[uswds])` selector before any other selectors. When a component has the `uswds` property (or 'flag') present, it is said to be rendering in "V3 Mode"; that is, in compliance with USWDS v3. Because this will eventually be the default, any styles that apply to "V1 Mode" or "Formation Mode" have to be excluded manually with this "Not USWDS" selector.
+Design System web components will support either `.css` or `.scss` stylesheet types. The Stencil generator will automatically create the component's stylesheet as `.css` but in some cases it will be necessary or preferred to update the stylesheet extension to `.scss` which you are encouraged to do.
 
-For example, if your va-gizmo component needs to have labels with green text in V1 mode, but blue text in V3 mode, you can do this in the va-gizmo.scss stylesheet:
-
-```css
-:host(:not[uswds]) label {
-  color: green;
-}
-
-label {
-  color: red;
-}
-```
+It can be helpful to make use of the `:host` pseudo-class function when defining your styles. Read more about the [:host function](https://developer.mozilla.org/en-US/docs/Web/CSS/:host_function) and review existing components for examples of where it may be appropriate to use in your stylesheet.
 
 ### Test coverage
-As with all code, test coverage is critical. This is especially true with shared code. Aim for at least 90% unit test coverage before declaring a component to be `stable`.
 
-## Timeline to get component to prod
+As with all code, test coverage is critical. This is especially true with shared code. 
 
-1. [Experimental design ]({{ site.baseurl }}/about/contributing-to-the-design-system)  is proposed and approved
+All components are required to have end-to-end tests located in the `web-components/src/components/va-new-component/test/` folder having the `.e2e.ts` extension. Stencil E2E tests verify your components in a real browser using Puppeteer.
+
+Stencil provides many utility functions to help write e2e tests using Jest and Puppeteer. Review the Stencil documentation on [End-to-end Testing](https://stenciljs.com/docs/end-to-end-testing) for more information or review existing component tests for guidance.
+
+Unit testing is also encourage where appropriate. The [va-telephone component unit tests](https://github.com/department-of-veterans-affairs/component-library/blob/main/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx) can be used as an example.
+
+## Timeline to get a new component to prod
+
+1. [Experimental design ]({{ site.baseurl }}/about/contributing-to-the-design-system) is proposed and approved
 2. New component is created
 3. PR submitted, reviewed, revised, and approved
 4. New version of the component-library package is released

--- a/src/_about/developers/contributing.md
+++ b/src/_about/developers/contributing.md
@@ -118,7 +118,7 @@ All components are required to have end-to-end tests located in the `web-compone
 
 Stencil provides many utility functions to help write e2e tests using Jest and Puppeteer. Review the Stencil documentation on [End-to-end Testing](https://stenciljs.com/docs/end-to-end-testing) for more information or review existing component tests for guidance.
 
-Unit testing is also encourage where appropriate. The [va-telephone component unit tests](https://github.com/department-of-veterans-affairs/component-library/blob/main/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx) can be used as an example.
+Unit testing is also encouraged where appropriate. The [va-telephone component unit tests](https://github.com/department-of-veterans-affairs/component-library/blob/main/packages/web-components/src/components/va-telephone/test/va-telephone.spec.tsx) can be used as an example.
 
 ## Timeline to get a new component to prod
 

--- a/src/_about/developers/contributing.md
+++ b/src/_about/developers/contributing.md
@@ -47,13 +47,13 @@ PRs which make a change to the Design System should be manageable in size. This 
 - Keep PRs tightly focused
 - Keep the review process short
 
-Be sure to follow the steps outlined in the [Getting Started](/about/developers/contributing#getting-started) section above and submit your pull request when its ready. You can reach out to the #platform-design-system Slack channel with any other questions.
+Be sure to follow the steps outlined in the [Getting Started](/about/developers/contributing#getting-started) section above and submit your pull request when it's ready to be reviewed by the Design System Team engineers and designers. You can reach out to the #platform-design-system Slack channel with questions.
 
 ## Contributing new components
 
 This section details how to contribute new components. If you haven't read it already, refer to the [contributing to the design system]({{ site.baseurl }}/about/contributing-to-the-design-system) page for more information about the full process. If you're unsure if you're ready to start creating a new component, make sure you've gone through the [experimental design process details]({{ site.baseurl }}/about/contributing-to-the-design-system) first. 
 
-Reach out to the #platform-design-system Slack channel with any other questions.
+Reach out to the #platform-design-system Slack channel with questions.
 
 ### General considerations
 


### PR DESCRIPTION
This PR will update the developer contribution docs to make it clearer how teams can contribute back to the design system component library.

The page can be reviewed locally at: http://127.0.0.1:4000/about/developers/contributing

![Screenshot 2024-02-07 at 12 12 42 PM](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/bbf4bc9d-b1dd-4443-9e60-1d1b2c03df14)


closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2446