### PR TITLE
Bump to latest component release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/department-of-veterans-affairs/vets-design-system-documentation#readme",
   "devDependencies": {
-    "@department-of-veterans-affairs/component-library": "^35.0.0",
+    "@department-of-veterans-affairs/component-library": "^36.1.0",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-rename": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,13 +9,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@department-of-veterans-affairs/component-library@^35.0.0":
-  version "35.0.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-35.0.0.tgz#6d204a8a90fa9a1a4df98d2d21481b2214e0d3be"
-  integrity sha512-oNJr2Ywzv5Aya5Z9ksAqHLLNI8XkTy8qWjZQDn/P0dUvWNq8oxBVPAaMxGLkR2oPc9iiZchmMd//up7NWKBWTA==
+"@department-of-veterans-affairs/component-library@^36.1.0":
+  version "36.1.0"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-36.1.0.tgz#678a1d5fb4e3a7f6acc85ff5f428f48f705b5a9e"
+  integrity sha512-xKBVu5DRuSSaOaa0D/JP6msbwmfzDmC668J8wAaO+793VM1GSc9b1a5ZuC8z5y8moZl5lDIYZvR5inmp7juybg==
   dependencies:
-    "@department-of-veterans-affairs/react-components" "26.0.1"
-    "@department-of-veterans-affairs/web-components" "4.59.1"
+    "@department-of-veterans-affairs/react-components" "28.0.0"
+    "@department-of-veterans-affairs/web-components" "4.60.0"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -38,10 +38,10 @@
     element-closest "^3.0.1"
     foundation-sites "5"
 
-"@department-of-veterans-affairs/react-components@26.0.1":
-  version "26.0.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/react-components/-/react-components-26.0.1.tgz#38eeb0dbe14ffe5f4a5fad6007d4688b33eabfdf"
-  integrity sha512-qCT32ZH7m6B5QMScML+dd/urB4IVNHmiJfX2XTFNE2ROzi2C61A7XMtDEt4bILa1Dno4H49QVhCFe3DqV6rU4w==
+"@department-of-veterans-affairs/react-components@28.0.0":
+  version "28.0.0"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/react-components/-/react-components-28.0.0.tgz#8ff7bbc1303a68e7ad2806e743a8ee72416aa284"
+  integrity sha512-FJW/z+Tpr1SiOnxOLhdDtgjF0rtGqSc00yvMhItY+P29AL8UPRo6SiR6C3Ephi6MpeCzC6L3x0HhrdcYL6omMA==
   dependencies:
     classnames "^2.2.6"
     prop-types "^15.6.2"
@@ -49,10 +49,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/web-components@4.59.1":
-  version "4.59.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-4.59.1.tgz#295cf8c2f04f1913ceef0ecffe0da39a3b38616c"
-  integrity sha512-nAc/ER8voz0uVzOdKylqmH0A9v7Kv7k8ukbho0SjfVnDH09QcCGxcMkD8k+WIVYTW2pQBUytp4rgmV/x+GiJ1Q==
+"@department-of-veterans-affairs/web-components@4.60.0":
+  version "4.60.0"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-4.60.0.tgz#827180c22adba0dbfd0754828fb2b3a98c4ab0aa"
+  integrity sha512-uB4vMOTFf40uXeretV4FaW3wZx2bdax82LVc6sAs2orF0RNctQiZbd9E6nZzly3bEGoXfZ/haUdahYqcNQK09Q==
   dependencies:
     "@department-of-veterans-affairs/css-library" "^0.3.1"
     "@stencil/core" "^2.19.2"


### PR DESCRIPTION
This PR bumps the `component-library` dependency to its latest version, 36.1.0.