### PR TITLE
Update button-labels.md

### DIFF
--- a/src/_content-style-guide/button-labels.md
+++ b/src/_content-style-guide/button-labels.md
@@ -11,6 +11,6 @@ slug: button-labels
 ## Related
 
 * [Button]({{ site.baseurl }}/components/button)
-* [Button pair]({{ site.baseurl }}/components/button/button-group)
+* [Button group]({{ site.baseurl }}/components/button/button-group)
 
 

--- a/src/_content-style-guide/button-labels.md
+++ b/src/_content-style-guide/button-labels.md
@@ -11,6 +11,6 @@ slug: button-labels
 ## Related
 
 * [Button]({{ site.baseurl }}/components/button)
-* [Button pair]({{ site.baseurl }}/components/button/button-pair)
+* [Button pair]({{ site.baseurl }}/components/button/button-group)
 
 


### PR DESCRIPTION
This PR fixes the broken link that's currently on the "Button labels" page in the content style guide