### PR TITLE
Unbury Conditionally Revealed guidance

### DIFF
--- a/src/_components/form/checkbox.md
+++ b/src/_components/form/checkbox.md
@@ -131,6 +131,8 @@ anchors:
 - If there are too many options to display on a mobile screen.
 - If a user can only select one option from a list (use radio buttons instead).
 
+{% include content/conditionally-revealed-fields.md %}
+
 ### Errors
 
 * Checkbox groups typically appear inside of `<fieldset>`s. The class name of `usa-input-error` may be placed on the `<fieldset>` that contains all of the checkboxes.

--- a/src/_components/form/radio-button.md
+++ b/src/_components/form/radio-button.md
@@ -77,6 +77,8 @@ anchors:
 * Use the [Description text](#description-text) variation to provide additional details about one or more radio button options. This variation is superseded by the Tile variation.
 * Use the [Tile](#tile) variation to provide additional details about one or more radio button options within a large and well defined tap target. 
 
+{% include content/conditionally-revealed-fields.md %}
+
 ### Errors
 
 * Radio buttons typically appear inside of `<fieldset>`s. The class name of `usa-input-error` may be placed on the `<fieldset>` that contains all of the radio buttons.

--- a/src/_includes/content/conditionally-revealed-fields.md
+++ b/src/_includes/content/conditionally-revealed-fields.md
@@ -1,0 +1,13 @@
+### Conditionaly revealed fields
+
+In the radio button and the checkbox components, we offer an option to conditionally reveal fields when the user selects an answer. They’re often used to group related questions together, by revealing a single follow-up question only when they’re relevant to the user.
+
+Conditionally revealed fields can be used if the following conditions are met:
+
+1. There should only be one reveal on a page.
+2. When the revealed trigger is selected, you must be able to tab directly into the newly revealed field (Which is why we've put the "other" question last.)
+3. The newly revealed question field must be understood by itself.  For example, don't just say "Other". Instead say: 
+
+> Since your relationship with the veteran was not listed, please describe it here
+
+{% include component-example.html alt="An example of a conditionally revealed field" file="/images/patterns/ask-users-for/relationship/relationship-to-veteran-other.png" caption="Example of asking the relationship to the Veteran with radio buttons and a conditionally revealed field." width="50%" %}

--- a/src/_patterns/ask-users-for/a-single-response.md
+++ b/src/_patterns/ask-users-for/a-single-response.md
@@ -116,6 +116,12 @@ The "One thing" can be:
 
 That one decision or question may require more than one input from the user as they fill out a form. However, by following this pattern you can [reduce the cognitive load](https://www.nngroup.com/articles/minimize-cognitive-load/) required to complete the form by focusing the user on a specific question and its answer.
 
+
+{% include content/conditionally-revealed-fields.md %}
+
+
+
+
 ## Code usage
 
 Refer to the following component variations to implement this pattern:

--- a/src/_patterns/ask-users-for/relationship.md
+++ b/src/_patterns/ask-users-for/relationship.md
@@ -41,17 +41,7 @@ anchors:
 * **Use either a drop down or radio buttons.** Options should include spouse, child, parent, executor/administrator of estate or other.
 * **Provide a way to give a ‘None of the above’ answer.** A radio button labeled “Other” should be provided.
 
-#### Conditionally revealed fields
-
-Conditionally revealed fields can be used if the following conditions are met:
-
-1. There should only be one reveal on a page.
-2. When the revealed trigger is selected, you must be able to tab directly into the newly revealed field (Which is why we've put the "other" question last.)
-3. The newly revealed question field must be understood by itself.  For example, don't just say "Other". Instead say: 
-
-> Since your relationship with the veteran was not listed, please describe it here
-
-{% include component-example.html alt="An example of a conditionally revealed field" file="/images/patterns/ask-users-for/relationship/relationship-to-veteran-other.png" caption="Example of asking the relationship to the Veteran with radio buttons and a conditionally revealed field." width="50%" %}
+{% include content/conditionally-revealed-fields.md %}
 
 ### Components used in this pattern
 


### PR DESCRIPTION
Currently, guidance for conditionally revealed fields is buried in the "Relationship to the Veteran" Pattern. This PR turns that guidance into a partial, so it can be included on
- Ask users for a single response (one thing per page)
- Radio Group
- Checkbox Group

When the forms team has a content-agnostic version of this pattern available in the forms library, I will update the guidance with links to that code.