### PR TITLE
bump component-library to 42.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/department-of-veterans-affairs/vets-design-system-documentation#readme",
   "devDependencies": {
-    "@department-of-veterans-affairs/component-library": "^42.0.0",
+    "@department-of-veterans-affairs/component-library": "^42.1.0",
     "gulp": "^4.0.2",
     "gulp-clean": "^0.4.0",
     "gulp-rename": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tar": ">=6.2.1"
   },
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^10.1.2",
+    "@department-of-veterans-affairs/formation": "^11.0.5",
     "@department-of-veterans-affairs/css-library": "^0.3.1"
   },
   "engines": {

--- a/src/assets/stylesheets/_components/_badge.scss
+++ b/src/assets/stylesheets/_components/_badge.scss
@@ -10,12 +10,12 @@
 .va-sidebarnav .usa-sidenav-list > li, 
 main {
   .site-sidenav-status {
-    font-size: 1rem;
-    padding-right: 0.5rem;
+    font-size: 0.625rem;
+    padding-right: 0.3125rem;
   }
 
   .site-component-status-heading .site-component-status {
-    font-size: 2rem;
+    font-size: 1.25rem;
   }
 
   .site-component-status--use,
@@ -58,9 +58,9 @@ main {
 }
 
 .site-component-badge-link {
-  font-size: 1.5rem;
+  font-size: 0.9375rem;
   margin-left: units(0.5);
-  padding: 0.1rem 0.7rem;
+  padding: 0.0625rem 0.4375rem;
   border-radius: 2px;
   text-transform: uppercase;
 }

--- a/src/assets/stylesheets/_components/_component-checklist.scss
+++ b/src/assets/stylesheets/_components/_component-checklist.scss
@@ -12,7 +12,7 @@
 
   &__totals {
     margin: units(2) 0;
-    font-size: 2rem;
+    font-size: 1.25rem;
     font-weight: bold;
   }
 }

--- a/src/assets/stylesheets/_components/_contributors.scss
+++ b/src/assets/stylesheets/_components/_contributors.scss
@@ -4,7 +4,7 @@
 
   &__title {
     font-family: $font-serif;
-    font-size: 2rem;
+    font-size: 1.25rem;
     margin: units(0.5) 0;
   }
 }

--- a/src/assets/stylesheets/_components/_do-dont.scss
+++ b/src/assets/stylesheets/_components/_do-dont.scss
@@ -8,7 +8,7 @@
 .do-dont__heading {
   font-weight: $font-bold;
   font-family: $font-sans;
-  font-size: 2.2rem;
+  font-size: 1.375rem;
   margin: 0;
   border-bottom: 1px solid $color-gray-lighter;
   padding-bottom: units(2);

--- a/src/assets/stylesheets/_components/_example.scss
+++ b/src/assets/stylesheets/_components/_example.scss
@@ -2,7 +2,7 @@
   margin: units(2) 0 units(3) 0;
   border: 1px solid $color-gray-lighter;
   background-color: $color-gray-lightest;
-  border-radius: 0.4rem;
+  border-radius: 0.25rem;
 
   &__image {
     padding: units(2) 0 0 units(2);
@@ -20,7 +20,7 @@
   &__caption {
     padding: units(1) units(2);
     color: $color-base;
-    font-size: 1.5rem;
+    font-size: 0.9375rem;
     max-width: 72ex;
   }
 }

--- a/src/assets/stylesheets/_components/_header.scss
+++ b/src/assets/stylesheets/_components/_header.scss
@@ -47,13 +47,13 @@
 
 .site-header__logo-text {
   display: block;
-  font-size: 1.3125remrem;
+  font-size: 1.3125rem;
   font-weight: 300;
   font-style: normal;
   margin: $units-3 0;
 
   @include media($nav-width) {
-    font-size: 2remrem;
+    font-size: 2rem;
   }
 }
 

--- a/src/assets/stylesheets/_components/_header.scss
+++ b/src/assets/stylesheets/_components/_header.scss
@@ -47,13 +47,13 @@
 
 .site-header__logo-text {
   display: block;
-  font-size: 2.1rem;
+  font-size: 1.3125remrem;
   font-weight: 300;
   font-style: normal;
   margin: $units-3 0;
 
   @include media($nav-width) {
-    font-size: 3.2rem;
+    font-size: 2remrem;
   }
 }
 

--- a/src/assets/stylesheets/_components/_hero.scss
+++ b/src/assets/stylesheets/_components/_hero.scss
@@ -1,7 +1,7 @@
 .site-hero {
   background: #16171F;
   color: #fff;
-  padding: units(15) 0 19rem;
+  padding: units(15) 0 11.875rem;
   position: relative;
 
   .site-l-wrapper {

--- a/src/assets/stylesheets/_components/_iframe-preview.scss
+++ b/src/assets/stylesheets/_components/_iframe-preview.scss
@@ -51,7 +51,7 @@
   border-radius: 0;
   border: .5px solid white;
   border-bottom: 0;
-  font-size: 1.2rem;
+  font-size: 0.75rem;
   margin: 0;
   padding: $units-1 * 2 $units-1;
   width: 100%;
@@ -64,7 +64,7 @@
   }
 
   @include media($medium-screen) {
-    font-size: 1.6rem;
+    font-size: 1rem;
   }
 
   &.is-current {

--- a/src/assets/stylesheets/_components/_in-this-section.scss
+++ b/src/assets/stylesheets/_components/_in-this-section.scss
@@ -3,7 +3,7 @@
 
   &__list {
     @include media($medium-screen) {
-      columns: 2 20rem;
+      columns: 2 12.5rem;
       column-gap: units(2);
     }
     margin-top: 0;
@@ -15,7 +15,7 @@
 
   &__title {
     font-family: $font-serif;
-    font-size: 2rem;
+    font-size: 1.25rem;
     font-weight: normal;
     margin: 0.4em 0em;
   }

--- a/src/assets/stylesheets/_components/_mobile-nav.scss
+++ b/src/assets/stylesheets/_components/_mobile-nav.scss
@@ -43,7 +43,7 @@
   width: auto;
 
   .fa {
-    font-size: 1.8rem;
+    font-size: 1.125rem;
   }
 }
 

--- a/src/assets/stylesheets/_components/_on-this-page.scss
+++ b/src/assets/stylesheets/_components/_on-this-page.scss
@@ -1,5 +1,5 @@
 .site-on-this-page {
-  margin: 1rem;
+  margin: 0.625rem;
 
   &__list {
     margin-top: 0;
@@ -11,7 +11,7 @@
 
   &__title {
     font-family: $font-serif;
-    font-size: 2rem;
+    font-size: 1.25rem;
     margin: 0.4em 0em;
   }
 

--- a/src/assets/stylesheets/_components/_resource-links.scss
+++ b/src/assets/stylesheets/_components/_resource-links.scss
@@ -26,7 +26,7 @@
 // These styles are for links to resources per-component
 
 .site-component-resources-links {
-  margin: 1rem 1rem units(3) 1rem;
+  margin: 0.625rem 0.625rem units(3) 0.625rem;
 
   &__list {
     margin-top: 0;
@@ -37,7 +37,7 @@
 
   &__title {
     font-family: $font-serif;
-    font-size: 2rem;
+    font-size: 1.25rem;
     margin: units(0.5) 0;
   }
 

--- a/src/assets/stylesheets/_components/_search-results.scss
+++ b/src/assets/stylesheets/_components/_search-results.scss
@@ -108,7 +108,7 @@
   position: static;
   max-height: none;
   width: 100%;
-  font-size: 2rem;
+  font-size: 1.25rem;
   border: none;
   overflow: visible;
 
@@ -124,7 +124,7 @@
 
   .site-search-results__url {
     display: block;
-    font-size: 1.5rem;
+    font-size: 0.9375rem;
     color: $color-primary-alt-darkest;
   }
 }

--- a/src/assets/stylesheets/_components/_showcase.scss
+++ b/src/assets/stylesheets/_components/_showcase.scss
@@ -22,7 +22,7 @@
 }
 
 .site-showcase__heading {
-  font-size: 2rem;
+  font-size: 1.25rem;
   font-family: $font-sans;
   margin-top: 0;
 
@@ -194,9 +194,9 @@
 }
 
 .utility-value-color__chip {
-  height: .75rem;
+  height: 0.46875rem;
   border-radius: 50%;
-  width: .75rem;
+  width: 0.46875rem;
   display: inline-block;
   margin-right: 8px;
 }

--- a/src/assets/stylesheets/_components/_sidenav.scss
+++ b/src/assets/stylesheets/_components/_sidenav.scss
@@ -1,11 +1,11 @@
 .va-sidebarnav {
   $padding-override: 10px 16px 10px 12px;
-  margin: 4rem 0 0 4rem;
+  margin: 2.5rem 0 0 2.5rem;
   background-color: var(--vads-color-white);
 
   &__sub-section {
     margin: 0;
-    padding: 2rem 0rem 1rem 1.5rem;
+    padding: 1.25rem 0rem 0.625rem 0.9375rem;
     color: var(--vads-color-base);
   }
 

--- a/src/assets/stylesheets/_layout/_content-wrappers.scss
+++ b/src/assets/stylesheets/_layout/_content-wrappers.scss
@@ -128,7 +128,7 @@
   > ol,
   > ul {
     max-width: 77ch;
-    font-size: 1.6rem;
+    font-size: 1rem;
   }
 
   > ul:not(.usa-unstyled-list) {
@@ -176,13 +176,13 @@
     padding: units(2);
 
     .highlight {
-      font-size: 1.7rem;
+      font-size: 1.0625rem;
     }
   }
 
   > .va-introtext {
     font-family: $font-sans;
-    font-size: 2.2rem;
+    font-size: 1.375rem;
     margin: units(3) 0;
   }
 }

--- a/src/assets/stylesheets/_layout/_site-content.scss
+++ b/src/assets/stylesheets/_layout/_site-content.scss
@@ -13,13 +13,13 @@
       display: block;
       position: -webkit-sticky;
       position: sticky;
-      top: 6rem;
+      top: 3.75rem;
       bottom: 0;
-      height: calc(100vh - 6rem);
+      height: calc(100vh - 3.75rem);
       overflow-y: auto;
       flex-basis: 30%;
-      min-width: 25rem; // the lack of this causes the sidenav to not display at 840px for some odd reason
-      max-width: 28rem;
+      min-width: 15.625rem; // the lack of this causes the sidenav to not display at 840px for some odd reason
+      max-width: 17.5rem;
     }
   }
 

--- a/src/assets/stylesheets/application.scss
+++ b/src/assets/stylesheets/application.scss
@@ -49,7 +49,7 @@ font-matter: yay
   left: 0;
   padding: 0.625rem 0.9375rem;
   position: absolute;
-  top: 2.625rem;
+  top: -2.625rem;
   transition: all 0.2s ease-in-out;
   z-index: 100;
 

--- a/src/assets/stylesheets/application.scss
+++ b/src/assets/stylesheets/application.scss
@@ -47,9 +47,9 @@ font-matter: yay
   background: transparent;
   color: $color-base;
   left: 0;
-  padding: 1rem 1.5rem;
+  padding: 0.625rem 0.9375rem;
   position: absolute;
-  top: -4.2rem;
+  top: 2.625rem;
   transition: all 0.2s ease-in-out;
   z-index: 100;
 

--- a/src/testing/doctors.html
+++ b/src/testing/doctors.html
@@ -157,8 +157,8 @@ $( function() {
     background: #fff;
     border: 1px solid #666;
     list-style: none;
-    max-height: 23rem;
-    max-width: 46rem;
+    max-height: 14.375rem;
+    max-width: 28.75rem;
     padding: 0;
     overflow-y: scroll;
   }
@@ -182,8 +182,8 @@ $( function() {
 
   .custom-combobox-input  {
     font-family: $font-sans;
-    font-size: 1.7rem;
-    max-width: 41.6rem;
+    font-size: 1.0625rem;
+    max-width: 26rem;
   }
 
   .custom-combobox-input :invalid {
@@ -196,13 +196,13 @@ $( function() {
     background-image: url(arrow-down.svg);
     background-position: right 1.3rem center;
     background-repeat: no-repeat;
-    background-size: 1.3rem;
+    background-size: 0.8125rem;
     border: 1px solid $color-gray;
     border-left: 0;
     display: block;
     text-indent: -999em;
-    height: 4.4rem;
-    width: 4.4rem;
+    height: 2.75rem;
+    width: 2.75rem;
     color: black;
   }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,13 +9,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@department-of-veterans-affairs/component-library@^42.0.0":
-  version "42.0.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-42.0.0.tgz#a4da1305ac0cdf47b6efa80ebaae358eeb601b38"
-  integrity sha512-aOTjfIHgZm+paz6xCs30ByCL+9tof807aKJeqGVuDwvj83rw3WI5u6MD+xlp9TynPP1thVcN4x6luBGSj9fzGA==
+"@department-of-veterans-affairs/component-library@^42.1.0":
+  version "42.1.0"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-42.1.0.tgz#c526fc4a10428e0253298426130bd9fcb1655692"
+  integrity sha512-kFj0UcNJugabXzth28elLhibr9fsNflnUvBu6oZsicnHzKPru1MgyQS/YC54eNEKSRp5KBIfi6zW7qY+HsG69A==
   dependencies:
     "@department-of-veterans-affairs/react-components" "28.1.0"
-    "@department-of-veterans-affairs/web-components" "9.0.0"
+    "@department-of-veterans-affairs/web-components" "9.1.1"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -36,10 +36,10 @@
     "@divriots/style-dictionary-to-figma" "^0.4.0"
     rimraf "^5.0.5"
 
-"@department-of-veterans-affairs/formation@^10.1.2":
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-10.1.2.tgz#79008f8c6720b15c67ac9747c3758f6700e5b51f"
-  integrity sha512-XWtY7t7Ud5lKgtiZbdNetv2eQoPuXfGNf2EznDeGnd1zTXa15SqZ+DvXtLe7E2c9dq65xF8M2pvwh/j8jyxMMQ==
+"@department-of-veterans-affairs/formation@^11.0.5":
+  version "11.0.5"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/formation/-/formation-11.0.5.tgz#20ce74597501244ba73f1e390b098c34854dd4b3"
+  integrity sha512-tYgmOKomXVqUEMN4ajXx/9mVfZwp8yTCjiC8UYG094jyWS2uQR2PhGEzpwp2XDCK1hRFFiV+CK5qROzeORfDWA==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.15.4"
     domready "^1.0.8"
@@ -57,10 +57,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/web-components@9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-9.0.0.tgz#cc3878182ed01184868d557cd983106729a96850"
-  integrity sha512-tTRR369ReUGSyqrk6GyGIBmB/fI88jIYUwKMDeowl41RJbTMx8Rhyt1kwPa1fO8qMTBa1S1cRZ1T9blq21IY6w==
+"@department-of-veterans-affairs/web-components@9.1.1":
+  version "9.1.1"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-9.1.1.tgz#807039281992b2151e28e8001f725bcbcc05fe25"
+  integrity sha512-LzAmIld8tBgVoCl42Dm09U0BjiTfsLoTVlZQEXOtGES8KgoPq8UD/Fro2yFlrK/5buJeSjtKHarapXgxXWgsuw==
   dependencies:
     "@department-of-veterans-affairs/css-library" "^0.7.0"
     "@stencil/core" "^2.19.2"


### PR DESCRIPTION
This PR bumps the version of component-library to 42.1.0

**After updating formation and rem values**:

<img width="1544" alt="Screenshot 2024-05-29 at 2 04 06 PM" src="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/8867779/64619b12-7589-4cdb-a65c-bb374a235a1c">

<img width="1544" alt="Screenshot 2024-05-29 at 2 07 07 PM" src="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/8867779/539098e5-5f03-4941-9ed1-380d8e5421ba">

<img width="1550" alt="Screenshot 2024-05-29 at 2 08 22 PM" src="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/8867779/c0443fce-a42b-4a02-8093-5e55116f4075">


