### PR TITLE
Remove forward slash from site.js src link

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -25,5 +25,5 @@
   Create a cache-busting string based on build timestamp.
 {% endcomment -%}
 {%- assign cacheBust = site.time | date:'?v=%s' -%}
-<script src="{{ '/assets/javascripts/site.js/' | prepend: site.baseurl | append: cacheBust }}"></script>
+<script src="{{ '/assets/javascripts/site.js' | prepend: site.baseurl | append: cacheBust }}"></script>
 <script src="{{ '/vendor/javascripts/formation.js' | prepend: site.baseurl | append: cacheBust }}"></script>


### PR DESCRIPTION
The search functionality isn't working and I believe it's because there's a rogue forward slash on the src path for the script that handles it so this PR will remove that.

<img width="1092" alt="Screenshot 2024-06-10 at 5 01 35 PM" src="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/872479/5a8821aa-a07c-4bfe-9476-e38f358c422f">
