### PR TITLE
Fix story link to display component in storybook properly

### DIFF
--- a/src/_components/divider.md
+++ b/src/_components/divider.md
@@ -11,7 +11,7 @@ intro-text: "Dividers are used sparingly to separate significant sections of con
 
 ### Stars
 
-{% include storybook-preview.html story="components-divider--default-story" %}
+{% include storybook-preview.html story="components-divider--default" %}
 
 ## Usage
 


### PR DESCRIPTION
Linked to the wrong story, which is causing it not to display.

![image](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/1631062/f4c2de49-57c3-4d7e-b107-d204d700e35a)
