### PR TITLE
Removes all sketch links. [Amends #2472]

### DIFF
--- a/src/_components/form/input-message.md
+++ b/src/_components/form/input-message.md
@@ -41,8 +41,6 @@ anchors:
   - All field sets are interactive
   - Last fieldset demonstrates error state
 
-- [Design specs](https://www.sketch.com/s/afd69a1f-72d2-430b-9b62-285e9d3f479c/a/9P4QlQn)
-
 ## Usage
 
 ### When to use this variation

--- a/src/_components/sidenav.md
+++ b/src/_components/sidenav.md
@@ -3,7 +3,6 @@ layout: component
 title: Sidenav
 intro-text: "Hierarchical, vertical navigation to place at the side of a page."
 github-title: va-sidenav
-sketch-link: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/6C33CB80-7176-4959-89E1-DBBD51CC029A/canvas
 anchors:
   - anchor: Examples
   - anchor: Usage

--- a/src/_patterns/help-users-to/check-eligibility.md
+++ b/src/_patterns/help-users-to/check-eligibility.md
@@ -5,7 +5,6 @@ permalink: /patterns/help-users-to/check-eligibility
 sub-section: help-users-to
 intro-text: "Follow this pattern to help users to check their eligibility for a benefit or service."
 research-title: help-users-to-check-eligibility
-sketch-link: https://sketch.com/s/610156b6-f281-4497-81f3-64454fc72156
 status: use-deployed
 anchors:
   - anchor: Usage

--- a/src/_patterns/help-users-to/complete-a-sub-task.md
+++ b/src/_patterns/help-users-to/complete-a-sub-task.md
@@ -8,7 +8,6 @@ title: Complete a sub task
 aka: Sub-task, Wizard
 intro-text: "Helps users complete a shorter task before, or within, a larger process or flow." 
 research-title: sub-task
-sketch-link: https://www.sketch.com/our-workspace-the-pattern-library/specific-page-for-this-pattern
 status: use-with-caution-available
 anchors:
   - anchor: Usage

--- a/src/_patterns/help-users-to/keep-a-record-of-submitted-information.md
+++ b/src/_patterns/help-users-to/keep-a-record-of-submitted-information.md
@@ -4,7 +4,6 @@ permalink: /patterns/help-users-to/keep-a-record-of-submitted-information
 sub-section: help-users-to
 title: Keep a record of submitted information
 intro-text: "This pattern provides the user with a printable record of their submission."
-sketch-link: https://www.sketch.com/s/c8df169f-5b02-4999-befb-34c7b3b62ba9/p/8B8D4C83-E246-4F59-8601-9D076322A8E5/canvas
 status: use-deployed
 anchors:
   - anchor: Usage
@@ -48,10 +47,6 @@ The component that contains the prompt to print the confirmation page should app
 * [Featured content]({{ site.baseurl }}/components/featured-content)
 * [Button - Primary]({{ site.baseurl }}/components/button)
 * [Link - Download]({{ site.baseurl }}/components/link/#download)
-
-### Page templates available for this pattern
-
-* [Form Confirmation page template](https://www.sketch.com/s/c8df169f-5b02-4999-befb-34c7b3b62ba9/p/8B8D4C83-E246-4F59-8601-9D076322A8E5/canvas)
 
 ## Content considerations
 

--- a/src/_patterns/help-users-to/navigate-a-long-list.md
+++ b/src/_patterns/help-users-to/navigate-a-long-list.md
@@ -10,7 +10,6 @@ contributors: Peter Russo (VAOS)
 added: 7/5/2022
 intro-text: Allows users to navigate and process a long list of items by progressively displaying additional items as needed.
 research-title: Show more options
-sketch-link: https://www.sketch.com/s/610156b6-f281-4497-81f3-64454fc72156/p/AC70760E-54B7-41E1-982A-26E3B29049DF
 status: use-with-caution-candidate
 anchors:
   - anchor: Usage


### PR DESCRIPTION
I decided to remove the broken links to Sketch even though we do not have all templates in Figma just yet.