### PR TITLE
Update formatting of title tags examples

### DIFF
--- a/src/_content-style-guide/title-tags.md
+++ b/src/_content-style-guide/title-tags.md
@@ -40,6 +40,7 @@ We format title tags differently for forms and multi-page subtasks. Some form co
 
 Each page in the flow should have the plain language form or task name as the title tag. This may be different from the H1.
 
-Example: Apply For VA Health Care \| Veterans Affairs (NOT Form 10-10ez) \| Veterans Affairs)
-
-Example: Income Limits \| Veterans Affairs (NOT What’s Your Address) \| Veterans Affairs)
+- Example: Income Limits \| Veterans Affairs
+  - Instead of: What's Your Address \| Veterans Affairs
+- Example: Apply For VA Health Care \| Veterans Affairs
+  - Instead of: Form 10-10ez \| Veterans Affairs


### PR DESCRIPTION
Updated formatting on the examples in the [Exception 2: forms and subtasks title tags section](https://design.va.gov/content-style-guide/title-tags#exception-2--forms-and-subtasks) to be more clear. The current formatting doesn't exactly match the text in the word doc shared in #2415, which is resulting in incorrect guidance. I broke the examples out into a nested UL for easier understanding.