### PR TITLE
Remove ARIA label guidance for phone numbers

### DIFF
--- a/src/_includes/content/phone-numbers.md
+++ b/src/_includes/content/phone-numbers.md
@@ -11,13 +11,8 @@ Using the [Telephone component]({{ site.baseurl }}/components/telephone) will ap
 * Use a verb ahead of the number. Use "call" or "call us at..." for phone numbers and "text" or "text us at" for text numbers.
 * When a phone number has (TTY: 711) included, it should be formatted in parenthesis directly following the phone number. Example: 866-440-1238 (TTY: 711) or 866-440-1238, ext. 4 (TTY: 711)
 
-### Links and aria labels
+### Links
 * Hyperlink all phone numbers, including TTY numbers. It’s not a requirement to link the "call" or "text" verb that precedes the number. We do however include "TTY" in the link and aria label to make it clear that it's specifically for TTY so that users who need the service see it and so those who do not do not unintentionally call a TTY number.
-* Include an aria label using spaces between the digits and periods between sections in order to have screen readers read the phone number one digit at a time like a phone number, rather than as thousands or hundreds. For example:
-  * `<a href="tel:+18008271000" aria-label="8 0 0. 8 2 7. 1 0 0 0.">800-827-1000</a>`
-  * `<a href="tel:711" aria-label="TTY. 7 1 1.">TTY: 711</a>`. 
-* If the phone number has an extension, use this format for the aria label:
-  * `<a href="tel:5551231234,4" aria-label="5 5 5. 1 2 3. 1 2 3 4. extension. 4.">555-123-1234, ext. 4</a>`
 
 If for some reason you cannot use the Telephone component, you are responsible for meeting the same formatting and accessibility guidance when creating links to phone numbers. 
 


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3040

This removal is based on the background outlined in this issue https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2884 and discussions with the a11y group at VA. We have removed the ARIA label from the telephone component itself, so this guidance should also be updated to remove that guidance for links, as spacing out the phone number in a label is no longer needed.