### PR TITLE
Update links.md - add "on this page" link for new section

### DIFF
--- a/src/_content-style-guide/links.md
+++ b/src/_content-style-guide/links.md
@@ -6,6 +6,7 @@ anchors:
   - anchor: Considerations
   - anchor: Link text
   - anchor: Formatting
+  - anchor: Linking to pages on VA.gov
   - anchor: Linking to documents and other file sources
   - anchor: Linking to external sites
 ---


### PR DESCRIPTION
Adding the missing On this Page link for the new section on the [links page](https://design.va.gov/content-style-guide/links) "Linking to pages on VA.gov"

<img width="341" alt="Screenshot 2024-08-05 at 9 47 31 AM" src="https://github.com/user-attachments/assets/61a85845-a4bf-4f73-8cb0-36449892ec51">
