### PR TITLE
Update redirects.md - Remove extraneous "On this page"

### DIFF
--- a/src/_components/url-standards/redirects.md
+++ b/src/_components/url-standards/redirects.md
@@ -16,8 +16,6 @@ anchors:
 
 Teams must formally request a redirect before implementation so they can be vetted for accuracy and appropriateness, and implemented with full validation across environments. That request also kicks off work to update all internal links and identifies existing redirects that may need to be updated.
 
-{% include _site-on-this-page.html %}
-
 ## Usage
 
 ### When to use a redirect


### PR DESCRIPTION
We had a bonus "On this page" section on the [URL Redirects page](https://design.va.gov/components/url-standards/redirects). Thanks @danbrady for the catch!