### PR TITLE
Update URL standards guidance for Vanity URLs and Form flow URLs

### DIFF
--- a/src/_components/url-standards/index.md
+++ b/src/_components/url-standards/index.md
@@ -7,13 +7,16 @@ title: URLs
 permalink: /components/url-standards/
 sub-pages:
   - sub-page: Redirects
+  - sub-page: Vanity URLs
 anchors:
-  - anchor: URL standards 
-  - anchor: Vanity URLs
+  - anchor: Changing URLs or retiring content
+  - anchor: URL standards
+  - anchor: Guidelines for URLs in form flows
+  - anchor: Guidelines for anchor tags
+  - anchor: Guidelines for parameters in URLs
 redirect_from:
   - /content-style-guide/url-standards
 ---
-
 
 # URLs
 
@@ -23,24 +26,22 @@ URLs are a highly visible attribute of your content that improve user experience
 - A high-level description of what the content is about
 - Information about how the content is related to other content within your site.
 
-
 A URL consists of a domain, sub-directories (optional), and a page name.
 
 ![The structure of a URL. Includes illustrations of URL segments including the domain, any subdirectories, and current page name]({{site.baseurl}}/images/url-segments.jpg)
- 
-**Changing URLs or retiring content**
-- Always implement a redirect when pages are taken down or the URL changes.
-- This ensures users do not encounter a 404 page or a broken link. 
-- This also tells search engines to no longer index a page, and to pass any SEO value along to the new page. 
 
 {% include _site-on-this-page.html %}
+
+## Changing URLs or retiring content
+- Always implement a [redirect](/components/url-standards/redirects) when pages are taken down or the URL changes.
+- This ensures users do not encounter a 404 page or a broken link. 
+- This also tells search engines to no longer index a page, and to pass any SEO value along to the new page. 
 
 ## URL standards 
 
 ### URLs must be unique and distinctly different.
 - Each URL must be completely unique within a domain.  Two pages with the same URL cannot exist on the same site. 
 - Each URL must be specific enough to clearly differentiate each page. We cannot have multiple pages with very similar URLs. 
-
 
 ### URLs must adhere to formatting standards.
 - All alpha characters in URLs must be lowercase. 
@@ -49,14 +50,12 @@ A URL consists of a domain, sub-directories (optional), and a page name.
 - URLs cannot include special characters (excluding the hyphen to separate words).
 - URLs cannot be longer than 2000 characters or it may not be rendered correctly by all browsers. 
 
-
 ### URLs must be structurally accurate.
 - URLs must accurately represent the placement and hierarchy of the content/page. 
   - The hierarchy and structure represented in the URL help users and search engines understand the location and relationship between content on the site. 
 - URLs should not include invalid or empty sub-directories (i.e. a directory that doesn’t contain any pages). 
   - Advanced users often use the URL as a means of navigation.  They often “hack a URL” by truncating it back to a sub-directory in order to get to broader content. 
   - If an empty sub-directory is absolutely necessary (i.e. for future planning), ensure the empty directory redirects users to a proper location so users do not get a 404.
-
 
 ### URLs must be readable, utilize plain language and include appropriate and consistent keywords.
 - Users (and search engines) must be able to easily “read” the URL and gain an understanding of its content and purpose..
@@ -66,23 +65,88 @@ A URL consists of a domain, sub-directories (optional), and a page name.
 - URLs must adhere to the same content styleguide and plain language standards as the content of the page.
 - URLs cannot have incorrect spelling or grammatical errors.  
 
-
 ### URLs must be clear, specific, and concise.
 - Do not use overly broad terms that may be misinterpreted, or shorten URLs so much that meaning and context are lost.  Be specific in describing the focus of the page.
 - Do not repeat keywords across multiple segments of a URL unless it is necessary to clarify meaning of the content. 
 - Do not include stop words - such as “a”, “the”, “and” - unless they are necessary to clarify meaning of the content.  
 
+## Guidelines for URLs in form flows
 
-### Guidelines for anchor tags (i.e. jump links) 
-When using jump links, or, anchored links, in addition to all the URL standards above, please use these guidelines when possible to create clean and understandable URL strings.
+These are the guidelines for the individual pages within a form flow or other sequential flow.  
+
+URL slugs used in form flows must follow all core URL standards in this guidance document.
+
+### Links to your form should point to the core URL of your form, not a specific page.
+When linking to your form from another page, a navigation component, or external communication, always link to the core URL and not to a specific page. 
+
+This will reduce the risk of breaking links if specific pages in your form flow are changed, reorganized, or removed.
+
+Example:
+- Incorrect link: www.va.gov/health-care/apply-for-health-care-form-10-10ez/introduction
+- Correct link: www.va.gov/health-care/apply-for-health-care-form-10-10ez/
+
+### Utilize standard URL slugs for core form pages.
+The following form flow pages have been standardized in the forms system:
+- `/introduction/`: typically the first page of the form flow
+- `/review-and-submit/`: step that allows the user to review their entered information prior to submitting
+- `/confirmation/`: final page of a form flow displayed after form submission
+
+### Avoid using sub-directories, child pages, or nested pages in your flow.
+Form flows are linear and should have a flat, sequential structure - in other words, all pages in a form flow live at the same level in the hierarchy.
+- Incorrect:  `form-url/page1/page2/page3/`
+- Correct: `form-url/page1/`, `form-url/page2/`, `form-url/page3/`, etc.
+
+An exception to this would be if there is a clear fork in your form flow for different scenarios that would be ideal to track separately. For example, if one form is for Veterans and family members, but each audience has slightly different form flows, the structure would be:
+- `/form-url/veteran/page1/`
+- `/form-url/family/page1/`
+
+### Use logical numbering when collecting multiple responses to a single question.
+
+For questions in a form that allow users to enter multiple responses - also known as a list and loop - numbering of those responses should start at 1 and increment upwards.
+
+The numbering can be embedded in the URL slug or be appended to the URL as a parameter.
+
+Embedded URL example:
+- `/form-url/dependent-1/`
+- `/form-url/dependent-2/`
+
+Parameter example
+- `/form-url/dependent/?name=1`
+- `/form-url/dependent/?name=2`
+
+If using parameters, see the [standards for URL parameters](#guidelines-for-parameters-in-urls).
+
+### Avoid incorporating chapter names in the URL structure.
+For forms using chapter labels, incorporating those labels into each page slug can make it more challenging if chapters are renamed or reorganized.
+
+An alternative is to use a similar initial term for pages that are directly related.
+
+### For related steps in a flow, consider using the same initial term.
+Using the same initial term in a URL slug can help to identify related pages in analytics.
+
+Examples:
+- Collecting more information on entries from a list and loop pattern
+  - `/dependent-1-contact` 
+  - `/dependent-1-address` 
+  - `/dependent-2-contact` 
+  - `/dependent-2-address` 
+- A question where the response results in a follow-up question
+  - `/form-url/home-ownership/`
+  - `/form-url/home-value/`
+- A series of questions all related to the same topic 
+  - `/form-url/military-branch/`
+  - `/form-url/military-service-period/`
+  - `/form-url/military-other-names/`
+
+## Guidelines for anchor tags 
+When using anchored links or "jump links", in addition to all the URL standards above, please use these guidelines when possible to create clean and understandable URL strings.
 
 - Anchor tag IDs should be treated as part of the URL and preferably follow all the same standards as URLs.
 - Ideally the tag ID should be plain language keywords that help provide meaning to the content, e.g. using a primary keyword from the associated heading. This works best for anchor tags on relatively static headings such as the Hub page. 
-  - Example:  This link provides a user with quick access to tasks for managing their health care benefits - https://www.va.gov/health-care/#manage-your-health-and-benefits
+  - Example:  This link provides a user with quick access to tasks for managing their health care benefits - `www.va.gov/health-care/#manage-your-health-and-benefits`
 - If the heading is lengthy, or could potentially change over time, using an ID (i.e. the content ID from drupal) is a another option. This works well for creating anchor links to accordions that hold frequently asked questions.
 
-
-### Guidelines for parameters in URLs 
+## Guidelines for parameters in URLs 
 
 URL parameters - also known as query strings - are values added to the end of a URL that filter or organize the information on a page. Parameters are used for a number of reasons - most commonly for pagination, anchoring, filtering or sorting data, indicating language, or searching.
 
@@ -101,41 +165,3 @@ When adding parameters to your URL, in addition to all the URL standards above, 
 - For multi-select type values, combine the values into a single parameter rather than exposing the key multiple times in a URL multiple times (i.e. `color=blue,red,white` vs `color=blue&color=red&color=white`).
 - Avoid linking to URLs with parameters. Link to the static or canonical URL when possible.
 - If multiple parameters are used in a query string, set a priority and list them in a consistent order.
-
-
-## Vanity URLs 
-
-A vanity URL is a short, simple, memorable and readable URL that utilizes the existing domain (va.gov) and redirects users to a specific page of the va.gov site.  
-- Example: www.va.gov/vre takes users to https://www.va.gov/careers-employment/vocational-rehabilitation/ 
-
-
-A “shortened URL” is a short, simple URL, but is generally made up of a randomized set of characters. VA does not currently provide a URL shortener service. We also do not recommend using external shortening services (i.e. bitly.com) as they can often be blocked and not always trusted by Veterans. 
-
-
-### About vanity URLs
-
-- The structure of a VA.gov vanity URL is the "va.gov" plus a short 1-2 keyword segment -  www.va.gov/[keyword-keyword] 
-  - We do not use sub-domains for vanity urls (i.e. education.va.gov) 
-  - We do not use custom top-level domains for vanity urls (i.e. www.va.apply) 
-- We do not maintain the visibility of the vanity URL in a user’s browser.  Once they enter the vanity URL, they are immediately redirected to the appropriate landing page and the actual canonical URL for that page will be displayed in their browser.  
-
-**When to use a vanity URL**
-- To provide a short and memorable URL for high profile content or tool on va.gov that lives 3 or more levels deep or has a URL with 70 or more characters. 
-- To provide an easy to remember and speak/type URL for a campaign landing page.
-
-**When not to use a vanity URL:**
-- For content that exists external to va.gov.
-- For files or documents such as a pdf.
-- For content or tools that live within the top 1-2 levels of the site already (i.e. www.va.gov/health-care). 
-- For content in the Resources and Support area of the site.
-
-### Guidance for choosing a vanity URL
-
-- Vanity URLs must be easy to say and type, as they are often used in print, video and audio campaigns where users have to understand, remember and then enter them into their browser.
-- Avoid the need to change keyboards on a device to enter the vanity URL (i.e. switching between alpha and numeric character keyboards) when possible.
-- Ensure assisted tech users easily speak the URL to access it. 
-- Use keywords that match the meaning and context of the landing page. 
-- Vanity URL cannot create confusion or alarm when seen out of on it's own. Vanity URLs are top level URLs of VA.gov, so creating a vanity URL using sensitive or alarming keywords can create confusion if someone encounters it without the context of the campaign message.   
-- Follow all URL standards when determining your vanity URL, to ensure it is unique, accurate, readable and properly formatted. 
-
-

--- a/src/_components/url-standards/redirects.md
+++ b/src/_components/url-standards/redirects.md
@@ -1,5 +1,5 @@
 ---
-layout: component
+layout: default
 title: Redirects
 permalink: /components/url-standards/redirects
 has-parent: /components/url-standards/
@@ -9,12 +9,17 @@ anchors:
   - anchor: Redirect requests and implementation process 
 ---
 
-**A redirect serves 2 purposes:**
+# URL Redirects
+
+A URL redirect serves 2 purposes:
+
 1.  It protects the Veteran's experience by making sure they are sent to a valid destination page rather than receiving a 404 (page not found) error
 
 2.  It informs search engines of the new location of a page so they can update their index and search results, and transfer the search value to the new URL
 
 Teams must formally request a redirect before implementation so they can be vetted for accuracy and appropriateness, and implemented with full validation across environments. That request also kicks off work to update all internal links and identifies existing redirects that may need to be updated.
+
+{% include _site-on-this-page.html %}
 
 ## Usage
 
@@ -52,4 +57,4 @@ Examples of these changes are:
 
 If you need to implement a redirect, a request must first be submitted to VA.gov Information Architecture.  This request will ensure the redirect is valid and accurate, and will kick-off processes to ensure all internal links are appropriately updated. 
 
-<a class="vads-c-action-link--blue" href="https://github.com/department-of-veterans-affairs/va.gov-team/issues/new/choose">Submit a Redirect or URL change issue on GitHub</a>
+<a class="vads-c-action-link--blue" href="https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=redirect-request.md">Submit a Redirect or URL change issue on GitHub</a>

--- a/src/_components/url-standards/vanity-urls.md
+++ b/src/_components/url-standards/vanity-urls.md
@@ -1,0 +1,57 @@
+---
+layout: default
+title: Vanity URLs
+permalink: /components/url-standards/vanity-urls
+has-parent: /components/url-standards/
+anchors:
+  - anchor: About vanity URLs
+  - anchor: Usage
+  - anchor: Vanity URL requests and implementation process 
+---
+
+# Vanity URLs
+
+A vanity URL is a short, simple, memorable, and readable URL that utilizes the existing domain (va.gov) and redirects users to a specific page of the VA.gov site.
+- Example: `www.va.gov/trust` takes users to `https://www.va.gov/initiatives/veteran-trust-in-va/
+
+A "shortened URL" is also a short URL, but is generally made up of a randomized set of characters. VA does not currently provide a URL-shortener service. We do not recommend using external URL-shortener services (i.e. bitly.com or tinyurl.com) as they are often blocked and not always trusted.
+
+{% include _site-on-this-page.html %}
+
+## About vanity URLs
+
+- Vanity URLs at VA always begin with "www.va.gov" 
+  - We do not use or create sub-domains for vanity urls (i.e. `education.va.gov`)
+  - We do not use or create custom top-level domains for vanity urls (i.e. `www.va.apply`)
+- The "vanity" segment of the URL should be short, easy to type, and easy to remember, and should follow the general URL standards in formatting
+- We do not maintain the visibility of the vanity URL in a user's browser. Once they enter the vanity URL, they are immediately redirected to the appropriate landing page and the actual canonical URL for that page will be displayed in their browser.
+
+## Usage
+
+### When to use a vanity URL
+
+- To provide a short and memorable URL for campaigns that meet the following criteria:
+  - Campaign is for Veterans or their family members and caregivers
+  - AND has a national level focus (not just for a local facility or single area)
+  - AND has a campaign landing page that the vanity URL will point to
+
+### When not to use a vanity URL
+
+- For content that exists external to VA.gov
+- For files or documents such as a pdf
+- For general benefit content or tools (i.e. www.va.gov/health-care).
+- For content in Resources and support
+- To "claim" a URL that doesn't have content 
+
+### Guidance for choosing a vanity URL
+
+- Vanity URLs must be easy to say and type because they are often used in print, video and audio campaigns where users have to understand, remember, and sometimes manually enter them into their browser.
+- Consider how well assistive technology can read and speak the URL. 
+- Use keywords that match the meaning and context of the landing page and ensure the meaning is upheld when shortening titles to just a few keywords. For example, shortening a campaign called "Eligibility for disability compensation" to just `www.va.gov/eligibility` results in an overly broad URL that can be misunderstood outside of the campaign messaging. 
+- A vanity URL should not include sensitive or alarming keywords that could create confusion when seen out of context on it’s own (i.e. `www.va.gov/evacuation`).  
+- Follow all general URL standards to ensure it is unique, accurate, readable and properly formatted.
+
+## Vanity URL requests and implementation process
+Vanity URL requests must be submitted to VA.gov Information Architecture for validation, approval, and implementation.
+
+<a class="vads-c-action-link--blue" href="https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=redirect-request.md">Submit a vanity URL request on GitHub</a>


### PR DESCRIPTION
Per @mnorthuis updates to VADS guidance for URL standards:

- Broke out Vanity URL guidance into its own child page of URL standards
- Added "sub-URL" guidance for form flows to URL standards main page
- Updated formatting on all three URL component pages (including redirects page)
- Updated link to submit GitHub issue on Vanity URLs and Redirects pages

https://github.com/department-of-veterans-affairs/va.gov-team/issues/88407 https://github.com/department-of-veterans-affairs/va.gov-team/issues/90080