### PR TITLE
Prefill pattern - add alerts with links to the 2 pages related to prefill

### DIFF
--- a/src/_components/form/prefill.md
+++ b/src/_components/form/prefill.md
@@ -15,6 +15,17 @@ anchors:
   - anchor: Content considerations
 ---
 
+<va-alert
+  status="warning"
+  slim
+>
+    <div class="vads-u-margin-y--0">
+    <p class="vads-u-margin-y--0">
+      We may be replacing this page soon. <va-link href="/patterns/help-users-to/know-when-their-information-is-prefilled" text="See the new prefill pattern page for up-to-date guidance." ></va-link>
+    </p>
+    </div>
+</va-alert>
+
 ## Examples
 
 ### Intro
@@ -23,7 +34,7 @@ anchors:
   {% include_relative html/prefill-intro.html %}
 </div>
 
-### Step 
+### Step
 
 <div class="site-showcase">
   {% include_relative html/prefill-step.html %}
@@ -42,7 +53,7 @@ anchors:
 ### How this component works
 
 * **Intro variation uses Alert - Informational.** The Intro variation of this component is an instance of the [Alert - Informational]({{ site.baseurl }}/components/alert#informational-alert) component, but without a header.
-* **Step variation uses Alert - Background-only Informational.** The Step variations of this component is an instance of the [Alert - Background-only with icon - Informational]({{ site.baseurl }}/components/alert#background-color-only-alert-with-icon) component. 
+* **Step variation uses Alert - Background-only Informational.** The Step variations of this component is an instance of the [Alert - Background-only with icon - Informational]({{ site.baseurl }}/components/alert#background-color-only-alert-with-icon) component.
 
 ### Placement
 

--- a/src/_patterns/help-users-to/know-how-their-information-is-updated.md
+++ b/src/_patterns/help-users-to/know-how-their-information-is-updated.md
@@ -12,6 +12,17 @@ anchors:
   - anchor: Research findings
 ---
 
+<va-alert
+  status="warning"
+  slim
+>
+    <div class="vads-u-margin-y--0">
+    <p class="vads-u-margin-y--0">
+      We are updating this pattern. Please note that some guidance may be out of date. <va-link href="/patterns/help-users-to/know-when-their-information-is-prefilled" text="See the new prefill pattern page for up-to-date guidance." ></va-link>
+    </p>
+    </div>
+</va-alert>
+
 ## Usage
 
 ### When to use this pattern
@@ -25,7 +36,7 @@ anchors:
 
 ### When not to use this pattern
 
-* **When an update in this form will not update their VA.gov profile.**  If a contact information addition or change will **not** update the user's VA.gov profile then use the text "*Any updates you make here to your [type of contact information] will only apply to this application.*" 
+* **When an update in this form will not update their VA.gov profile.**  If a contact information addition or change will **not** update the user's VA.gov profile then use the text "*Any updates you make here to your [type of contact information] will only apply to this application.*"
 
 ### When to use caution
 
@@ -47,7 +58,7 @@ However, some forms show a set of data taken from VA.gov profile and display the
 
 * In this example, at the start of the Request a Board Appeal process, the user is shown information that we have on file but that cannot be changed in this application. A note below the information calls out how to get the information updated.
 
-#### Communicate information that can be edited 
+#### Communicate information that can be edited
 
 {% include component-example.html alt="Contact information from the Request a Board Appeal application." file="/images/patterns/help-users-to/know-how-their-information-is-updated/board-appeal-contact-information.png" caption="The user is shown contact information stored in their profile that can be edited before continuing with the process." width="50%" %}
 


### PR DESCRIPTION
Summary:

CAIA recommended adding some alerts to the 2 pages that pertain to the prefill pattern.

Form - Prefill page:
![Screenshot 2024-11-04 at 4 04 32 PM](https://github.com/user-attachments/assets/331daa69-29ff-4b93-aed3-73e94bb0c6a0)

Know how their information is updated - Pattern page:
![Screenshot 2024-11-04 at 4 05 01 PM](https://github.com/user-attachments/assets/5513aa19-3f76-4d7c-882e-f53d1ee558a6)


Ticket this addresses: https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/168