### PR TITLE
Update table a11y guidance

### DIFF
--- a/src/_components/table.md
+++ b/src/_components/table.md
@@ -77,4 +77,6 @@ The v3 default table is a standard table and does not offer the responsive stack
 
 ## Accessibility considerations
 
-<a class="vads-c-action-link--blue" href="https://designsystem.digital.gov/components/table/#accessibility-accordion">Refer to the U.S. Web Design System for accessibility guidance</a>
+- Tables should be used to display tabular data, which is structured data made up of rows and columns. A table allows the information to be easily interpreted by visually associating row and column headers.
+- _Do not_ use tables for layout purposes. Tables should only be used for data that has inherent relationships, not for design purposes.
+- <a href="https://designsystem.digital.gov/components/table/#accessibility-accordion">Refer to the U.S. Web Design System for additional accessibility guidance</a>.


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3505

- Updated a11y considerations for table usage
- Kept link for USWDS' table guidance, but downgraded it to a standard link at the bottom of the list.

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/35d687c1-99f0-405f-967b-ebb969365651" />
