### PR TITLE
Remove v1 table docs section

### DIFF
--- a/src/_components/table.md
+++ b/src/_components/table.md
@@ -38,12 +38,6 @@ anchors:
 
 {% include storybook-preview.html height="410px" story="uswds-va-table--sortable" link_text="Sortable va-table" %}
 
-## Examples - v1
-
-### Responsive stacked table (v1 Default)
-
-{% include storybook-preview.html height="400px" story="components-va-table--default" link_text="va-table v1 along with additional variations"  %}
-
 ## Usage
 
 <a class="vads-c-action-link--blue" href="https://designsystem.digital.gov/components/table/">Refer to the U.S. Web Design System for usage guidance</a>


### PR DESCRIPTION
Removes [this section](https://design.va.gov/components/table#examples---v1) since v1 code was removed:

<img width="1779" alt="image" src="https://github.com/user-attachments/assets/f57468fb-a209-4293-8465-72f3d25248aa" />
