### PR TITLE
Add Storybook local preview steps and update the localhost port number

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Tested using `node` v18.19.0 and `yarn` v1.22.19.
 
 6. **Verify in browser: [localhost:4000](http://localhost:4000/)**
 
+7. **Start the Storybook server for component previews**
+
+In a new terminal window, navigate to your `component-library/packages/storybook` directory and run:
+
+   ```
+   $ yarn static-storybook-server
+   ```
+
+8. **Verify Storybook is running: [localhost:8080](http://localhost:8080/)**
+
 ## Adding content to the documentation site
 
 To add content, you will need to look into `/src` directory. This will be the source from which [Jekyll](http://jekyllrb.com) builds the site.

--- a/_config.yml
+++ b/_config.yml
@@ -91,6 +91,6 @@ exclude:
 
 # Default for building locally.
 # See configuration files in jekyll-configs/ for environment overrides.
-storybook_path: "http://localhost:6006"
+storybook_path: "http://localhost:8080"
 storybook_prod_uswds_path: "https://design.va.gov/storybook/?path=/docs/uswds"
 storybook_mobile_path: "https://department-of-veterans-affairs.github.io/va-mobile-library"


### PR DESCRIPTION
These steps should get the components loading again locally. But....

⚠️  The component-library PR below needs to be merged first.

🛠️  After that's merged, pull down those component-library updates locally and run `yarn install` (just needs to be done once). Then the Storybook server should start using the steps this PR adds.

Related component-library pr:

- https://github.com/department-of-veterans-affairs/component-library/pull/1495