### PR TITLE
Headers: Adds a11y guidance on avoiding links in headers. [Fixes #2146]

### DIFF
--- a/.github/prompts/Guidance-follow-content-style-guide.md
+++ b/.github/prompts/Guidance-follow-content-style-guide.md
@@ -1,5 +1,0 @@
-This repository contains guidance for creating applications for VA.gov and the VA Health and Benefits mobile application using components and patterns. Your goal is to review any guidance changes in this repo and ensure they meet the guidelines in the following sections of the Content Style Guide:
-
-* Use correct capitalization: [Capitalization](../../src/_content-style-guide/capitalization.md)
-* Follow standard American English and AP Style: [Punctuation](../../src/_content-style-guide/punctuation.md)
-* Use active voice: [Use active voice](../../src/_content-style-guide/plain-language/use-active-voice.md)

--- a/.github/prompts/Guidance-follow-content-style-guide.prompt.md
+++ b/.github/prompts/Guidance-follow-content-style-guide.prompt.md
@@ -1,0 +1,10 @@
+This repository contains guidance for creating applications for VA.gov and the VA Health and Benefits mobile application using components and patterns. Your goal is to review any guidance changes in this repo and ensure they meet the guidelines in the following sections of the Content Style Guide:
+
+* Avoid abbreviations and acronyms unless they are very common and familiar to designers and developers: [Abbreviations and acronyms](../../src/_content-style-guide/abbreviations-and-acronyms.md)
+* Use correct capitalization: [Capitalization](../../src/_content-style-guide/capitalization.md)
+* We differ from AP Style on numbers in order to meet the needs of users on the web and on mobile: [Numbers](../../src/_content-style-guide/numbers.md)
+* Follow standard American English and AP Style: [Punctuation](../../src/_content-style-guide/punctuation.md)
+* Use active voice: [Use active voice](../../src/_content-style-guide/plain-language/use-active-voice.md)
+* Avoid or minimize references to branded program names: [Avoid branded names](../../src/_content-style-guide/plain-language/avoid-branded-names.md)]
+* [Use contractions](../../src/_content-style-guide/plain-language/use-contractions.md)
+* [Use short sentences](../../src/_content-style-guide/plain-language/use-short-sentences.md)

--- a/src/_components/link/index.md
+++ b/src/_components/link/index.md
@@ -206,6 +206,8 @@ Refer to the [Content Style Guide on Links]({{ site.baseurl }}/content-style-gui
 
 {% include content/links-vs-buttons.md %}
 
+{% include content/avoid-links-in-headers.md %}
+
 ## Related
 
 * [Button]({{ site.baseurl }}/components/button)

--- a/src/_foundation/typography.md
+++ b/src/_foundation/typography.md
@@ -152,6 +152,8 @@ Don’t change heading level in order to use a different font size.
 </div>
 </div>
 
+{% include content/avoid-links-in-headers.md %}
+
 ### Eyebrow
 
 <div class="site-showcase">

--- a/src/_includes/content/avoid-links-in-headers.md
+++ b/src/_includes/content/avoid-links-in-headers.md
@@ -1,0 +1,22 @@
+### Avoid turning headers into links in most contexts
+
+#### Why avoid headers as links?
+
+* **Cognitive load and user expectations.** Headings serve as structural elements that help users with assistive technologies understand page organization. When a heading is also a link, it creates dual functionality that can confuse users. Screen reader users may not expect headings to be actionable.
+* **Challenging keyboard navigation.** Keyboard users tab through links as a primary navigation method. Headers that are links can be accidentally activated during normal page exploration.
+* **Confusing screen reader announcements.** Screen readers announce headings and links differently. Combining them results in unclear announcements like "Heading level 2, link, Text," making it harder to understand the element's purpose.
+* **Unnecessary redundancy.** The linked text in a heading is often repeated elsewhere on the page, creating distracting duplication.
+
+#### When it's appropriate to use links in headers
+
+An exception can be made in the [Card]({{ site.baseurl }}/components/card) component, where:
+
+* Space is limited, and combining the heading and link reduces visual clutter
+* The card functions as a single actionable unit (such as linking to a detail page)
+* The design makes the linked heading the primary call-to-action in the card, minimizing confusion
+
+#### When it's not appropriate
+
+* In normal page content where headings primarily serve as organizational aids
+* When multiple links are associated with the heading, making the primary action unclear
+* When the link in the heading duplicates another visible link that immediately follows it


### PR DESCRIPTION
## Summary

Adds a11y guidance in both Typography > Headers and Link that makes clear when it is and is not appropriate to use links in headers. Also, adds to the copilot prompt in VS Code for reviewing guidance using the content style guide.

## Related Issue

Closes #[#2146](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2146)

## Preview Environment Links

<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/4041)
<!-- end placeholder -->
