### PR TITLE
Checkbox: Adds guidance on choosing between variations.

### DIFF
--- a/src/_components/form/checkbox.md
+++ b/src/_components/form/checkbox.md
@@ -92,27 +92,27 @@ anchors:
 
 ### Forms pattern - Single error
 
-{% include storybook-preview.html story="uswds-va-checkbox-group--forms-pattern-single-error" link_text="va-checkbox group forms pattern single error" height="600px" %}
+{% include storybook-preview.html story="uswds-va-checkbox-group--forms-pattern-single-error" link_text="Error state for single checkbox pattern" height="600px" %}
 
 ### Forms pattern - Multiple
 
-{% include storybook-preview.html story="uswds-va-checkbox-group--forms-pattern-multiple" link_text="va-checkbox group forms pattern multiple" height="600px" %}
+{% include storybook-preview.html story="uswds-va-checkbox-group--forms-pattern-multiple" link_text="Multiple checkbox pattern example" height="600px" %}
 
 ### Error
 
-{% include storybook-preview.html story="uswds-va-checkbox-group--error" link_text="va-checkbox group error" %}
+{% include storybook-preview.html story="uswds-va-checkbox-group--error" link_text="Checkbox group with error state" %}
 
 ### Internationalization
 
-{% include storybook-preview.html story="uswds-va-checkbox-group--internationalization" link_text="va-checkbox group internationalization" %}
+{% include storybook-preview.html story="uswds-va-checkbox-group--internationalization" link_text="Checkbox group with internationalization" %}
 
 ### Indeterminate
 
-Use the indeterminate state when a checkbox has a sublist of checkbox selections that can change from selected to unselected.
+Use the indeterminate state for a parent checkbox that controls a sublist of checkboxes. The parent checkbox shows this state when some (but not all) child checkboxes are selected.
 
-See pattern guidance when asking users [a mutually exclusive answer](https://design.va.gov/patterns/ask-users-for/a-mutually-exclusive-answer).
+See our pattern guidance on [asking users for a mutually exclusive answer](https://design.va.gov/patterns/ask-users-for/a-mutually-exclusive-answer).
 
-{% include storybook-preview.html story="uswds-va-checkbox--indeterminate" link_text="va-checkbox group indeterminate" %}
+{% include storybook-preview.html story="uswds-va-checkbox--indeterminate" link_text="Checkbox with indeterminate state" %}
 
 ## Usage
 

--- a/src/_components/form/checkbox.md
+++ b/src/_components/form/checkbox.md
@@ -129,6 +129,10 @@ See pattern guidance when asking users [a mutually exclusive answer](https://des
 * If there are too many options to display on a mobile screen.
 * If a user can only select one option from a list (use radio buttons instead).
 
+#### Choosing between variations
+
+* **Use the [Forms pattern - Single](#forms-pattern---single) and [Forms pattern - Multiple](#forms-pattern---multiple) variations for implementing the [Ask users for a single response]({{ site.baseurl }}/patterns/ask-users-for/a-single-response) pattern.** These component variations are specifically designed to help implement the single response pattern. The [Forms pattern - Single error](#forms-pattern---single-error) variation shows error handling for the component variation. For checkbox groups used outside of this pattern, for example on a longer form page, use the [Label header](#label-header) checkbox group variation.
+
 {% include content/conditionally-revealed-fields.md %}
 
 ### Errors

--- a/src/_components/form/checkbox.md
+++ b/src/_components/form/checkbox.md
@@ -112,7 +112,7 @@ Use the indeterminate state for a parent checkbox that controls a sublist of che
 
 See our pattern guidance on [asking users for a mutually exclusive answer](https://design.va.gov/patterns/ask-users-for/a-mutually-exclusive-answer).
 
-{% include storybook-preview.html story="uswds-va-checkbox--indeterminate" link_text="Checkbox with indeterminate state" %}
+{% include storybook-preview.html story="uswds-va-checkbox--indeterminate" link_text="Checkbox with indeterminate state" height="300px" %}
 
 ## Usage
 

--- a/src/_components/form/text-input.md
+++ b/src/_components/form/text-input.md
@@ -110,7 +110,9 @@ See [form error handling]({{ site.baseurl }}/components/form/#error-handling) fo
   type="secondary"
 ></va-link-action>
 
-### Choosing between variations
+### Additional guidance for VA
+
+#### Choosing between variations
 
 * **Required.** Indicates to the user that the text input field is required in order to submit the form.
 * **Pattern.** Allows for a pattern of characters to be required for the text input entry to be valid.
@@ -130,7 +132,7 @@ See [form error handling]({{ site.baseurl }}/components/form/#error-handling) fo
 * **Prefix and Suffix.** Allows an icon or text to be set as an input prefix and/or suffix. See [USWDS Input Prefix and Suffix](https://designsystem.digital.gov/components/input-prefix-suffix/) for additional guidance. 
 * **Widths.** Indicates to the user the expected length of text input by sizing the field relative to what is expected.
 
-### Errors
+#### Errors
 
 * Refer to the specific error examples above.
 
@@ -140,7 +142,7 @@ See [form error handling]({{ site.baseurl }}/components/form/#error-handling) fo
   type="secondary"
 ></va-link-action>
 
-### Hint text
+#### Hint text
 
 * Refer to the [hint text example](#hint-text) above.
 
@@ -154,7 +156,7 @@ See [form error handling]({{ site.baseurl }}/components/form/#error-handling) fo
 
 {% include content/using-message-aria-describedby.md %}
 
-### Native Events
+#### Native Events
 
 * Native onInput and onBlur events are available on this component. They can be used by adding the event handler to your component and it will then listen to the event and respond accordingly when the event fires.
 

--- a/src/_includes/content/conditionally-revealed-fields.md
+++ b/src/_includes/content/conditionally-revealed-fields.md
@@ -1,12 +1,12 @@
 #### Conditionally revealed fields
 
-In the radio button and checkbox components, we offer an option to conditionally reveal fields when the user selects an answer. These fields are often used to group related questions together by revealing a single follow-up question only when they’re relevant to the user.
+Conditionally revealed fields show additional form elements only when a user selects a specific option. They help reduce visual complexity by showing follow-up questions only when they're relevant.
 
-Conditionally revealed fields can be used if the following conditions are met:
+When using conditionally revealed fields:
 
-1. There should only be one reveal on a page.
-2. When the revealed trigger is selected, you must be able to tab directly into the newly revealed field (Which is why we've put the "other" question last.)
-3. The newly revealed question field must be understood by itself.  For example, don't just say "Other". Instead, say:
+1. **Limit to one reveal per page.** Avoid confusing the user with multiple expanding sections.
+2. **Ensure keyboard accessibility.** When a user selects the trigger option, they should be able to tab directly into the newly revealed field (which is why the trigger option is placed last).
+3. **Make the revealed question self-explanatory.** Avoid vague labels like "Other" for text fields. Instead, use clear, specific labels that work independently:
 
 > Since your relationship with the veteran was not listed, please describe it here
 


### PR DESCRIPTION
## Summary

- **Checkbox: Adds guidance on choosing between variations. [Fixes #2204]**
- **Some copilot directed content improvements to guidance.**

## Related Issue

_If this PR resolves an open issue, please add the issue number here._

Closes [#2204](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2204)

## Preview Environment Links

<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/4043)
<!-- end placeholder -->
