### PR TITLE
Adjusted iframe heights for iframes that were still showing scrollbars

### DIFF
--- a/src/_components/alert/alert-expandable.md
+++ b/src/_components/alert/alert-expandable.md
@@ -23,15 +23,15 @@ anchors:
 
 ### Default (Informational)
 
-{% include storybook-preview.html story="components-va-alert-expandable--default" link_text="va-alert-expandable" %}
+{% include storybook-preview.html story="components-va-alert-expandable--default" link_text="va-alert-expandable" height="210px" auto_resize=false %}
 
 ### Warning alert
 
-{% include storybook-preview.html story="components-va-alert-expandable--warning" link_text="va-alert-expandable" %}
+{% include storybook-preview.html story="components-va-alert-expandable--warning" link_text="va-alert-expandable" height="210px" auto_resize=false %}
 
 ### Success alert
 
-{% include storybook-preview.html story="components-va-alert-expandable--success" link_text="va-alert-expandable" %}
+{% include storybook-preview.html story="components-va-alert-expandable--success" link_text="va-alert-expandable" height="210px" auto_resize=false %}
 
 ## Usage
 

--- a/src/_components/alert/index.md
+++ b/src/_components/alert/index.md
@@ -59,19 +59,19 @@ Used to indicate success.
 
 #### Informational alert (aka default)
 
-{% include storybook-preview.html story="alert--info" link_text="va-mobile__alert--info" is_mobile=true %}
+{% include storybook-preview.html story="alert--info" link_text="va-mobile__alert--info" is_mobile=true height="400px" auto_resize=false %}
 
 #### Warning alert
 
-{% include storybook-preview.html story="alert--warning" link_text="va-mobile__alert--warning" is_mobile=true %}
+{% include storybook-preview.html story="alert--warning" link_text="va-mobile__alert--warning" is_mobile=true height="400px" auto_resize=false %}
 
 #### Success alert
 
-{% include storybook-preview.html story="alert--success" link_text="va-mobile__alert--success" is_mobile=true %}
+{% include storybook-preview.html story="alert--success" link_text="va-mobile__alert--success" is_mobile=true height="400px" auto_resize=false %}
 
 #### Error alert
 
-{% include storybook-preview.html story="alert--error" link_text="va-mobile__alert--error" is_mobile=true %}
+{% include storybook-preview.html story="alert--error" link_text="va-mobile__alert--error" is_mobile=true height="400px" auto_resize=false %}
 
 ## Examples - Standard properties
 

--- a/src/_components/form/date-input.md
+++ b/src/_components/form/date-input.md
@@ -28,7 +28,7 @@ web-component: va-date
 {% include storybook-preview.html story="components-va-date--with-hint-text" link_text="va-date with hint text" %}
 
 ### With a custom required message
-{% include storybook-preview.html story="components-va-date--custom-required-message" link_text="va-date with a custom required message" %}
+{% include storybook-preview.html story="components-va-date--custom-required-message" link_text="va-date with a custom required message" height="275px" auto_resize=false  %}
 
 ### Default with error
 {% include storybook-preview.html story="components-va-date--error" link_text="va-date with error" %}

--- a/src/_components/form/progress-bar-segmented.md
+++ b/src/_components/form/progress-bar-segmented.md
@@ -21,35 +21,35 @@ anchors:
 
 ### Default
 
-{% include storybook-preview.html story="uswds-va-segmented-progress-bar--default" link_text="va-segmented-progress-bar v3 default" height="200px" %}
+{% include storybook-preview.html story="uswds-va-segmented-progress-bar--default" link_text="va-segmented-progress-bar v3 default" height="145px" auto_resize=false %}
 
 ### Step Labels
 
-{% include storybook-preview.html story="uswds-va-segmented-progress-bar--step-labels" link_text="va-segmented-progress-bar step labels" height="200px" %}
+{% include storybook-preview.html story="uswds-va-segmented-progress-bar--step-labels" link_text="va-segmented-progress-bar step labels" height="170px" auto_resize=false %}
 
 ### Centered Step Labels
 
-{% include storybook-preview.html story="uswds-va-segmented-progress-bar--centered-step-labels" link_text="va-segmented-progress-bar vcentered step labels" height="200px" %}
+{% include storybook-preview.html story="uswds-va-segmented-progress-bar--centered-step-labels" link_text="va-segmented-progress-bar vcentered step labels" height="170px" auto_resize=false %}
 
 ### Counters
 
-{% include storybook-preview.html story="uswds-va-segmented-progress-bar--counters" link_text="va-segmented-progress-bar counters" height="200px" %}
+{% include storybook-preview.html story="uswds-va-segmented-progress-bar--counters" link_text="va-segmented-progress-bar counters" height="205px" auto_resize=false %}
 
 ### Small Counters
 
-{% include storybook-preview.html story="uswds-va-segmented-progress-bar--small-counters" link_text="va-segmented-progress-bar small counters" height="200px" %}
+{% include storybook-preview.html story="uswds-va-segmented-progress-bar--small-counters" link_text="va-segmented-progress-bar small counters" height="190px" auto_resize=false %}
 
 ### Centered Counters
 
-{% include storybook-preview.html story="uswds-va-segmented-progress-bar--centered-counters" link_text="va-segmented-progress-bar centered counters" height="200px" %}
+{% include storybook-preview.html story="uswds-va-segmented-progress-bar--centered-counters" link_text="va-segmented-progress-bar centered counters" height="205px" auto_resize=false %}
 
 ### Centered Small Counters
 
-{% include storybook-preview.html story="uswds-va-segmented-progress-bar--centered-small-counters" link_text="va-segmented-progress-bar centered small counters" height="200px" %}
+{% include storybook-preview.html story="uswds-va-segmented-progress-bar--centered-small-counters" link_text="va-segmented-progress-bar centered small counters" height="190px" auto_resize=false %}
 
 ### Custom Header Level
 
-{% include storybook-preview.html story="uswds-va-segmented-progress-bar--custom-header-level" link_text="va-segmented-progress-bar custom header level" height="200px" %}
+{% include storybook-preview.html story="uswds-va-segmented-progress-bar--custom-header-level" link_text="va-segmented-progress-bar custom header level" height="190px" auto_resize=false %}
 
 ## Usage
 

--- a/src/_components/form/statement-of-truth.md
+++ b/src/_components/form/statement-of-truth.md
@@ -24,19 +24,19 @@ anchors:
 
 ### Default
 
-{% include storybook-preview.html height="500px" story="uswds-va-statement-of-truth--default" link_text=page.web-component %}
+{% include storybook-preview.html height="500px" story="uswds-va-statement-of-truth--default" link_text=page.web-component height="555px" auto_resize=false %}
 
 ### With Input Error
 
-{% include storybook-preview.html height="600px" story="uswds-va-statement-of-truth--with-input-error" link_text=page.web-component %}
+{% include storybook-preview.html height="600px" story="uswds-va-statement-of-truth--with-input-error" link_text=page.web-component height="605px" auto_resize=false %}
 
 ### With Custom heading
 
-{% include storybook-preview.html height="500px" story="uswds-va-statement-of-truth--with-custom-heading" link_text=page.web-component %}
+{% include storybook-preview.html height="500px" story="uswds-va-statement-of-truth--with-custom-heading" link_text=page.web-component height="555px" auto_resize=false %}
 
 ### With Prefilling
 
-{% include storybook-preview.html height="500px" story="uswds-va-statement-of-truth--with-prefilling" link_text=page.web-component %}
+{% include storybook-preview.html height="500px" story="uswds-va-statement-of-truth--with-prefilling" link_text=page.web-component height="555px" auto_resize=false %}
 
 ## Usage
 

--- a/src/_components/form/text-input.md
+++ b/src/_components/form/text-input.md
@@ -36,7 +36,7 @@ anchors:
 
 ### Autocomplete
 
-{% include storybook-preview.html story="uswds-va-text-input--autocomplete" link_text="va-text-input Autocomplete" %}
+{% include storybook-preview.html story="uswds-va-text-input--autocomplete" link_text="va-text-input Autocomplete" height="565px" auto_resize=false %}
 
 ### Hint Text
 
@@ -46,7 +46,7 @@ Also refer to the overall [form guidance]({{ site.baseurl }}/components/form#hin
 
 ### Inline Hint Text
 
-{% include storybook-preview.html story="uswds-va-text-input--with-inline-hint-text" link_text="va-text-input with inline Hint text" %}
+{% include storybook-preview.html story="uswds-va-text-input--with-inline-hint-text" link_text="va-text-input with inline Hint text" height="155px" auto_resize=false %}
 
 ### Additional Info
 

--- a/src/_components/modal/crisis-line-modal.md
+++ b/src/_components/modal/crisis-line-modal.md
@@ -20,7 +20,7 @@ anchors:
 
 ### Default
 
-{% include storybook-preview.html story="components-va-crisis-line-modal--default" link_text="va-crisis-line-modal default" %}
+{% include storybook-preview.html story="components-va-crisis-line-modal--default" link_text="va-crisis-line-modal default" height="700px" auto_resize=false %}
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Reviewed all the component pages to find iframes on the component pages that still had iframes and manually added a iframe height so that the iframe scrollbar would go away. 

## Related Issue

No ticket for this. It is related to this PR that was closed earlier with the goal of removing all the scrolling from iframes with the VADS. 

- #771 
- [Resizing iframe heights for storybook examples #3789](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/3789)

## Preview Environment Links

<!-- start placeholder for CI job -->

This will be updated automatically 🪄✨

<!-- end placeholder -->
