### PR TITLE
Destigmatizing language for weight: Fixing link

### DIFF
--- a/src/_content-style-guide/health-content/destigmatizing-language-for-weight.md
+++ b/src/_content-style-guide/health-content/destigmatizing-language-for-weight.md
@@ -139,6 +139,6 @@ We all can help reduce negative stereotyping, body shaming, and personal blaming
 
 ## Additional Resources
 
-[Weight Bias & Stigma | Rudd Center for Food Policy and Health (uconnruddcenter.org)](https://uconnruddcenter.org/research/weight-bias-stigma/)
+[Weight Bias & Stigma, Rudd Center for Food Policy and Health (uconnruddcenter.org)](https://uconnruddcenter.org/research/weight-bias-stigma/)
 
 [6 tips to help journalists improve news coverage of obesity (journalistsresource.org)](https://journalistsresource.org/health/myths-misinformation-obesity-stigmatizing-news-tips-journalists/)


### PR DESCRIPTION
## Summary

Fixing the first link under Additional resources. It wasn't linking in the live page although the preview looked okay; this may have been because of the vertical bar in the title, which is now a comma.