### PR TITLE
Alert: Adds a link to our downtime notification guidance in a number of components

### DIFF
--- a/src/_components/alert/index.md
+++ b/src/_components/alert/index.md
@@ -118,7 +118,7 @@ Any style of alert box can be modified to be a Slim alert. The iconography for S
 #### Additional uses of an alert
 
 * **To notify users about the status of the system:**
-  * **In-application system status.** An exception to the above is providing information to the user, unprompted, about a problem with a particular application. These [system status messages]({{ site.baseurl }}/content-style-guide/error-messages/system) typically use an error or warning variation and do not require user action.
+  * **In-application system status.** An exception to the above is providing information to the user, unprompted, about a problem with a particular application. These [system status messages]({{ site.baseurl }}/content-style-guide/error-messages/system) typically use an error or warning variation and do not require user action. For application-level maintenance, review the [downtime notifications guidance](https://depo-platform-documentation.scrollhelp.site/developer-docs/downtime-notifications).
   * **Access messages when a user tries to access an item that is not available to them.** [Access messages]({{ site.baseurl }}/content-style-guide/error-messages/access) typically warn the user that something they tried to access is not working correctly or is temporarily unavailable. These often use the error or warning variations.
 
 * **To respond to a user action:**

--- a/src/_components/banner/index.md
+++ b/src/_components/banner/index.md
@@ -35,7 +35,7 @@ anchors:
 * **Emergency or very urgent communications.** On the home page, Banner is to be used exclusively for urgent communications which notify Veterans, VA employees, and the public of events that affect VA services. For example, a government shutdown affecting VA services.
 * **Preparing a Veteran to visit a VA facility.** Many of the messages typically found in banners are managed by VA Facilities and help a Veteran prepare for their visit to a facility. Those messages include, but are not limited to:
   * Active threat training exercise warnings
-  * Changes to availability, hours, or wait times for emergency or urgent care 
+  * Changes to availability, hours, or wait times for emergency or urgent care
   * Construction on campus or in the area
   * COVID-19 operational updates
   * Holiday closures
@@ -45,12 +45,12 @@ anchors:
   * Delays in filling prescriptions
 * **Additional Veteran actions.** Finally there are additional messages that require an action from a Veteran that may use this component:
   * IRS deadline for benefit declarations
-  * Sign up for notifications 
+  * Sign up for notifications
 
 ### When to consider something else
 
 * **User feedback.** User feedback is provided via [feedback messages]({{ site.baseurl }}/content-style-guide/error-messages/feedback) that respond to an action a user has taken and to draw their attention to something that they need to correct or to confirm successful completion of a task. These messages are handled by the [Alert]({{ site.baseurl }}/components/alert) component.
-* **In-application system status, engagement, and access messages.** All of the messages in our [messages dictionary]({{ site.baseurl }}/content-style-guide/error-messages) are handled by the [Alert]({{ site.baseurl }}/components/alert) component.
+* **In-application system status, engagement, and access messages.** All of the messages in our [messages dictionary]({{ site.baseurl }}/content-style-guide/error-messages) are handled by the [Alert]({{ site.baseurl }}/components/alert) component. For application-level maintenance, review the [downtime notifications guidance](https://depo-platform-documentation.scrollhelp.site/developer-docs/downtime-notifications).
 * **News, promotion, new tools, etc.** Promotional items or general news that may be relevant to a broad audience of Veterans is better placed in the [Banner - Promo]({{ site.baseurl }}/components/banner/promo) component. To ensure that customers always know they can find critical service information in this area, don’t use Banner for general press, outreach, or administrative messages.
 * **System maintenance.** Before and during maintenance there are [specific system status messages]({{ site.baseurl }}/content-style-guide/error-messages/system) that we use to communicate the maintenance window to users which is handled by the [Banner - Maintenance]({{ site.baseurl }}/components/banner/maintenance) component. 
 * **Helping a Veteran maintain their health.** Another category of messages are broadly related to helping Veterans manage their health. These messages should be managed with a combination of Content Management System (CMS) components as follows:
@@ -63,13 +63,14 @@ anchors:
 ### How to use Banner
 
 * **Don't stack banners.** Only one Banner may appear on any page at one time. If multiple emergency issues occur at once, combine the message and link out to a landing page or to individual affected medical centers, for example.
-- **Info and warning only.** Banner is only available in `info` or `warning` styles.
-- **Dismissible by default.** Banners should generally be dismissible by the user.
-- **Links, not buttons.** Don't use buttons in Banner. [Buttons are reserved for actions whereas links are for navigation]({{ site.baseurl }}/components/link/#links-vs-buttons).
+* **Info and warning only.** Banner is only available in `info` or `warning` styles.
+* **Dismissible by default.** Banners should generally be dismissible by the user.
+* **Links, not buttons.** Don't use buttons in Banner. [Buttons are reserved for actions whereas links are for navigation]({{ site.baseurl }}/components/link/#links-vs-buttons).
 
 ### Placement
-- Content inside Banner remains aligned to the main page grid container. This might not be apparent on this site in smaller screens.
-- Can be used on homepage or, in true emergencies, on lower-level pages.
+
+* Content inside Banner remains aligned to the main page grid container. This might not be apparent on this site in smaller screens.
+* Can be used on homepage or, in true emergencies, on lower-level pages.
 
 {% include component-docs.html component_name=page.web-component %}
 
@@ -80,4 +81,4 @@ anchors:
 
 ## Accessibility considerations
 
-- Aria `role` of `banner` will be added to the child `va-alert` component to notify users that a banner is to be utilized as the `region`. 
+* Aria `role` of `banner` will be added to the child `va-alert` component to notify users that a banner is to be utilized as the `region`.

--- a/src/_components/banner/maintenance.md
+++ b/src/_components/banner/maintenance.md
@@ -10,6 +10,7 @@ status: use-deployed
 anchors:
   - anchor: Examples
   - anchor: Usage
+  - anchor: Behavior
 ---
 
 ## Examples
@@ -18,40 +19,30 @@ anchors:
 
 {% include storybook-preview.html story="components-va-maintenance-banner--default" link_text="va-maintenance-banner" height="225px" %}
 
-### Warning (upcomming maintenance)
+### Warning (upcoming maintenance)
 
 {% include storybook-preview.html story="components-va-maintenance-banner--maintenance-warning" link_text="va-maintenance-banner maintenance warning" height="225px" %}
 
 ## Usage
 
-### When to use MaintenanceBanner
+### When to use Banner - Maintenance
 
 * **System maintenance.** Before and during maintenance there are [specific system status messages]({{ site.baseurl }}/content-style-guide/error-messages/system) that we use to communicate the maintenance window to users. Maintenance messages are used when all (or most) unauthenticated and authenticated applications, tools, or sign in experiences across the entire site are affected (e.g., vets-api).
 
 ### When to consider something else
 
-* **Anything that is not a System status message.** This component is ONLY for site-wide [system status messages]({{ site.baseurl }}/content-style-guide/error-messages/system). There is no other appropriate use.
+* **Anything that is not a System status message.** This component is ONLY for site-wide [system status messages]({{ site.baseurl }}/content-style-guide/error-messages/system). There is no other appropriate use. For application-level maintenance, review the [downtime notifications guidance](https://depo-platform-documentation.scrollhelp.site/developer-docs/downtime-notifications).
 
-### Behavior
+## Behavior
 
-The content and UX behavior of sitewide maintenance banners are standardized. Only the duration, dates, and times are customizable. 
+The content and UX behavior of site-wide maintenance banners are standardized. Only the duration, dates, and times are customizable.
 
 The Public Website Team (Office of the CTO Digital Experience) publishes downtime maintenance banners.
 
-- Specify custom dates and times. 
-- Specify custom duration (how many hours or minutes) in the upcoming/before message. 
-- Times are always given in ET.
-- Sitewide maintenance banners are always dismissible per session.
-- The ‘upcoming’ before message should be published at least 12 hours in advance. (Can be more in advance when the outage is unusually long or comprehensive.)
-- Banner expires and automatically removed when downtime is complete.
-- A maximum of 3 banners are allowed simultaneously. 
-
-<!--
-#### When there are multiple banners simultaneously on a page 
-
-The front-end logic will prioritize the display order of banners like this: 
-
-1. Emergency homepage banner
-2. Site-wide maintenance banner
-3. Any other Veteran-action required banner
--->
+* Specify custom dates and times.
+* Specify custom duration (how many hours or minutes) in the upcoming/before message.
+* Times are always given in ET.
+* Site-wide maintenance banners are always dismissible per session.
+* The ‘upcoming’ before message should be published at least 12 hours in advance. (Can be more in advance when the outage is unusually long or comprehensive.)
+* Banner expires and automatically removed when downtime is complete.
+* A maximum of 3 banners are allowed simultaneously.


### PR DESCRIPTION
## Summary

Adds a link to our downtime notification guidance in Alert, Banner, and Banner - Maintenance, which are all places a user may look to find application-level downtime guidance.

## Related Issue

I did not create an issue for this but had it on a personal todo list for awhile (please excuse my bad behavior).

## Preview Environment Links

<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/4254)
<!-- end placeholder -->
