### PR TITLE
bump version of component-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "tar": ">=6.2.1"
   },
   "dependencies": {
-    "@department-of-veterans-affairs/css-library": "^0.22.0",
-    "@department-of-veterans-affairs/component-library": "^51.0.0",
+    "@department-of-veterans-affairs/css-library": "^0.22.2",
+    "@department-of-veterans-affairs/component-library": "^51.1.0",
     "@uswds/uswds": "^3.9.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,22 +9,22 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@department-of-veterans-affairs/component-library@^51.0.0":
-  version "51.0.0"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-51.0.0.tgz#bb5d12f3bf3fbafd8c32cd9764f1ae1985dfa37d"
-  integrity sha512-LLRVVVA/wfySKoB+t9AaPZhrkGySnFomiKnVPrPaWNUaOdOcOlIUFCB6rhcxBE6n8HLVXUXAO1mIPjo8ZN34Fw==
+"@department-of-veterans-affairs/component-library@^51.1.0":
+  version "51.1.0"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-51.1.0.tgz#75265f7adbaf0405519500b62e26f5bf315e2637"
+  integrity sha512-wpvIvVZobnEeBnnekYZ7uwyQlvyoeW5tEEJ3Zxwy8mlddT/3i/TrtbcMnmvEs7BptYLsV6jtJs/hNMBQth8AGw==
   dependencies:
     "@department-of-veterans-affairs/react-components" "28.1.0"
-    "@department-of-veterans-affairs/web-components" "19.0.0"
+    "@department-of-veterans-affairs/web-components" "19.1.0"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/css-library@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/css-library/-/css-library-0.22.0.tgz#b9672d13be28b2a86e120b2fa793fe23ecea5c9b"
-  integrity sha512-ebjFHDg3RtOJq1B/3QlrkEJyrq33eul0OVhorNp66vl4kxzpiWUQT6sQtk72dlyE52lB5yzyiLM3U6aWyfAIxw==
+"@department-of-veterans-affairs/css-library@^0.22.2":
+  version "0.22.2"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/css-library/-/css-library-0.22.2.tgz#514a2bf190650ef5f21ce6a7d19b16c8221583a0"
+  integrity sha512-GO9zdpsD3QkE6azLzqJVU2Et+4ffGQFl/Qd1MzjnzBxMZRTvavGH2PsXrVhtdj/cd1AP3qMnVsyu37SxGuoyVw==
   dependencies:
     "@divriots/style-dictionary-to-figma" "^0.4.0"
     "@uswds/uswds" "^3.9.0"
@@ -41,10 +41,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/web-components@19.0.0":
-  version "19.0.0"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-19.0.0.tgz#9c5327777a0fa8ff9b79bf69665bbac6521ee4db"
-  integrity sha512-xyiA+mwDdMBw8Y9A5uu+14a8uFt1Bf/r0LasDep3UzQznWBrfvVtbXJZC6fquU6sdkzuXqCNzZV96gx8AcomdQ==
+"@department-of-veterans-affairs/web-components@19.1.0":
+  version "19.1.0"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-19.1.0.tgz#f4bc82dd66e90952e24eb50a6b7f14be7a5098e2"
+  integrity sha512-Pv8RkvAo5C1N/7GO1RiH4sWb4RqGiIhUaEfA+TU5+qZFwEIwyTDzOudlhrZk6Vdosy4Z4rIr4EEWOqK0DZa9hQ==
   dependencies:
     "@stencil/core" "4.20.0"
     aria-hidden "^1.1.3"


### PR DESCRIPTION
<!--
  ## How to Title Your PR
  The titles of all PRs appear together on the [What's New](https://design.va.gov/about/whats-new) page. This page is meant to be easily and quickly scanned so a clear, concise explanation is important.

  We recommend PR titles to include updated page or section, start with present tense action verbs (e.g., Fixes, Adds, Improves, Updates), and describe what was updated.

  For example:
  - Checkbox: Adds Storybook examples
  - Experimental Components & Patterns: Improves submission guidance
  - Links: Fixes typos
  - Multiple Responses: Updates usage guidance
-->

## Summary

This PR updates the version of component-library to latest, 51.1.0.
## Related Issue

_If this PR resolves an open issue, please add the issue number here._

Closes #[Issue_number]

## Preview Environment Links

<!--

  A preview environment is automatically created and updated with every PR (including draft PRs). This allows you to review your changes in a browser just as they will appear after the PR is merged.

  Once you've committed a PR, automated checks will run and then a preview environment will be automatically generated.

  The URL of this preview environment follows this format:

  `https://dev-design.va.gov/[This_PR_number]`

  A minute or two after committing, you will see an entry in the GitHub timeline similar to this:

  > [Your Username] deployed to development [X time] ago - with Github Actions [View Deployment]

  Clicking the **View Deployment** button will open a browser window to preview your changes. Validate your updates are correct BEFORE submitting your PR for review.

  **NOTE:** The preview environment only works for PRs submitted to the official repository. It will not work for forked repositories.

-->

<!--
  Finally, please remove all these PR template comments before submitting. 🚀
-->

<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/4370)
<!-- end placeholder -->
