### PR TITLE
Alert: Adds link styling guidance

### DIFF
--- a/src/_components/alert/index.md
+++ b/src/_components/alert/index.md
@@ -168,6 +168,13 @@ When the user is required to do something in response to an alert, let them know
 * Messaging should be direct, concise, and in [plain language]({{ site.baseurl }}/content-style-guide/plain-language/).
 * Standard alerts must contain headings as opposed to Slim alerts which do not contain headings.
 
+### Links within alerts
+
+* **Use an action link when a link is needed.** The preferred usage of links in an alert is the [action link](#alert-with-action-link), which is a single link directing the user to a clear next step or call-to-action.
+  * A [Link - Active]({{ site.baseurl }}/components/link#active) style is an acceptable variation.
+* **Avoid using multiple links in a list.** Alerts should not includes lists of links. Shorten your alert message and include multiple links outside of the alert itself.
+* **Don't use bold text for standard links within alert messages.** The blue color and underline already provide sufficient visual distinction. Follow the same [link styling guidelines]({{ site.baseurl }}/content-style-guide/links/) and [bold text guidelines]({{ site.baseurl }}/content-style-guide/bold-text/) used elsewhere on VA.gov. Note that standard links are often a secondary action and appear alongside buttons, see [Alert - Sign-in]({{ site.baseurl }}/components/alert/alert-sign-in) for examples.
+
 ### Placement
 
 #### Web

--- a/src/_components/alert/index.md
+++ b/src/_components/alert/index.md
@@ -172,7 +172,7 @@ When the user is required to do something in response to an alert, let them know
 
 * **Use an action link when a link is needed.** The preferred usage of links in an alert is the [action link](#alert-with-action-link), which is a single link directing the user to a clear next step or call-to-action.
   * A [Link - Active]({{ site.baseurl }}/components/link#active) style is an acceptable variation.
-* **Avoid using multiple links in a list.** Alerts should not includes lists of links. Shorten your alert message and include multiple links outside of the alert itself.
+* **Use the correct link variation for specific actions.** For example, use the [Link - Directions]({{ site.baseurl }}/components/link#directions) variation when linking to a Maps application for a facility location. Use the [Telephone]({{ site.baseurl }}/components/telephone) component when linking to a phone number.
 * **Don't use bold text for standard links within alert messages.** The blue color and underline already provide sufficient visual distinction. Follow the same [link styling guidelines]({{ site.baseurl }}/content-style-guide/links) and [bold text guidelines]({{ site.baseurl }}/content-style-guide/bold-text) used elsewhere on VA.gov. Note that standard links are often a secondary action and appear alongside buttons, see [Alert - Sign-in]({{ site.baseurl }}/components/alert/alert-sign-in) for examples.
 
 ### Placement

--- a/src/_components/alert/index.md
+++ b/src/_components/alert/index.md
@@ -173,7 +173,7 @@ When the user is required to do something in response to an alert, let them know
 * **Use an action link when a link is needed.** The preferred usage of links in an alert is the [action link](#alert-with-action-link), which is a single link directing the user to a clear next step or call-to-action.
   * A [Link - Active]({{ site.baseurl }}/components/link#active) style is an acceptable variation.
 * **Avoid using multiple links in a list.** Alerts should not includes lists of links. Shorten your alert message and include multiple links outside of the alert itself.
-* **Don't use bold text for standard links within alert messages.** The blue color and underline already provide sufficient visual distinction. Follow the same [link styling guidelines]({{ site.baseurl }}/content-style-guide/links/) and [bold text guidelines]({{ site.baseurl }}/content-style-guide/bold-text/) used elsewhere on VA.gov. Note that standard links are often a secondary action and appear alongside buttons, see [Alert - Sign-in]({{ site.baseurl }}/components/alert/alert-sign-in) for examples.
+* **Don't use bold text for standard links within alert messages.** The blue color and underline already provide sufficient visual distinction. Follow the same [link styling guidelines]({{ site.baseurl }}/content-style-guide/links) and [bold text guidelines]({{ site.baseurl }}/content-style-guide/bold-text) used elsewhere on VA.gov. Note that standard links are often a secondary action and appear alongside buttons, see [Alert - Sign-in]({{ site.baseurl }}/components/alert/alert-sign-in) for examples.
 
 ### Placement
 


### PR DESCRIPTION
## Summary

Adds clear guidance for link styling within alert components to resolve confusion from health teams about when to bold links in alerts. The new "Links within alerts" section provides specific guidance on action links vs standard links and clarifies that bold text should not be used for standard links.

## Related Issue

Closes #4417

## Preview Environment Links

Preview will be available at: `https://dev-design.va.gov/[This_PR_number]` once automated checks complete.

Changes can be previewed at: `/components/alert/` in the "Links within alerts" section under "How to use alerts".<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/4421)
<!-- end placeholder -->