### PR TITLE
Remove incorrect accessibility guidance

### DIFF
--- a/src/_components/form/radio-button.md
+++ b/src/_components/form/radio-button.md
@@ -133,6 +133,3 @@ anchors:
   text="Refer to the U.S. Web Design System for accessibility guidance"
   type="secondary"
 ></va-link-action>
-### Additional accessibility considerations for VA
-
-* When using Safari with VoiceOver, it will read out the fieldset legend for each radio item when navigating through them. However, the recommended behavior is that the legend should only be read out at the end of the first radio option when tabbing into the group. This behaves as expected in other browsers with VoiceOver, but Safari does not support this. There currently is no workaround for this.

--- a/src/_patterns/ask-users-for/marital-information.md
+++ b/src/_patterns/ask-users-for/marital-information.md
@@ -152,17 +152,6 @@ This logic helps clarify whose information is being collected and is especially 
 Veterans, their spouse, or a dependent can complete forms. Depending on who is completing the form, some slight alterations to the text content may need to shift. Update content as needed. For example, shift "What is your current marital status" to "What is the Veteran's current marital status"?
 
 
-## Accessibility considerations
-
-### Radio button accessibility considerations
-
-<va-link-action
-  href="https://design.va.gov/components/form/radio-button"
-  text="Refer to the VADS Radio Button component for accessibility guidance"
-  type="secondary"
-></va-link-action>
-
-
 ## Research findings
 
 A [secondary research report](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/authenticated-patterns/Patterns/marital-status/Discovery%20Research%20Report.md) from April 2025 explores which VA forms ask questions related to an applicant's marital status and how they phrase these questions. It also provides recommendations that influenced the creation of this pattern. Learn more in the [research report](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/authenticated-patterns/Patterns/marital-status/Discovery%20Research%20Report.md).


### PR DESCRIPTION
## Summary

Unnecessary guidance was added to VADS regarding radio groups. The text explains a defect within Safari, and not within the design system. VO just reads radio groups differently than JAWS or NVDA.  This PR removes that guidance.

## Related Issue

Closes #4350

## Preview Environment Links

<!-- start placeholder for CI job -->

This will be updated automatically 🪄✨

<!-- end placeholder -->
