### PR TITLE
Fix typo in Link - Action docs

### DIFF
--- a/src/_components/link/action.md
+++ b/src/_components/link/action.md
@@ -47,7 +47,7 @@ The action link is an eye-catching link to start a digital service. An action li
 
 ### When to consider something else
 
-* **Use buttons for authentication action.s** Don’t use Link - Action for these actions: “sign up,” “submit” or “sign out.” For these actions, use [buttons]({{ site.baseurl }}/components/button) instead.
+* **Use buttons for authentication actions.** Don’t use Link - Action for these actions: “sign up,” “submit” or “sign out.” For these actions, use [buttons]({{ site.baseurl }}/components/button) instead.
 * **Use a button for going to the next step in a form.** Use Button - Primary for moving between steps of an online application or tool. This is considered an action rather than navigation. Note that we prefer a [Back link]({{ site.baseurl }}/components/link/#back) for navigation backward in a flow but have instances of using a Button - Secondary in most forms.
 * **Don’t use Link - Action for non-actions.** Link - Action is not meant to replace all links. It should be used explicitly for actions.
 


### PR DESCRIPTION
## Summary

Fix typo in Link - Action docs

## Related Issue

N/A

## Preview Environment Links

<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/4619)
<!-- end placeholder -->
