### PR TITLE
Adding accessibility guidance for va-link

### DIFF
--- a/src/_components/link/index.md
+++ b/src/_components/link/index.md
@@ -200,6 +200,7 @@ Refer to the [Content Style Guide on Links]({{ site.baseurl }}/content-style-gui
 ## Accessibility considerations
 
 * **Material honesty.** Do not style a link to look or behave like a button ([material honesty](https://alistapart.com/article/material-honesty-on-the-web/)).
+* **Screen magnification.** To ensure links are sized properly for screen magnification or browser zoomed-in users, wrap `<va-link>` in the appropriate semantic tag like `<p>`. `<va-link>` will not resize if it is wrapped in a `<div>`.
 * **Keyboard navigation.** The user must be able to navigate to links using the Tab key and activate links using the Enter key.
 * **Purpose and target.** Link text that doesn't indicate a clear purpose or destination makes it harder for everyone--especially screen reader users--to understand where they're getting routed off to.
 * **External links must indicate that they are external.** Follow the methods detailed in [linking to external sites]({{ site.baseurl }}/content-style-guide/links#linking-to-external-sites).


### PR DESCRIPTION
## Summary

In the accessibility cop channel we discussed issues with va-link not enlarging in some instances for users.  

We were finally able to recreate the issue in this way:
- In browser settings, change the font size to very large (this does not work when just using traditional browser zoom with ctrl and plus)

See this [slack thread for more details](https://dsva.slack.com/archives/C01DBGX4P45/p1735058549203829)

We need to update guidance to let teams know they need to wrap `<va-link>` in a semantic tag like `<p>`. We can't bake it into the component at this point, because there are other semantic tags that also work like headings and lists. A `<div>` or `<span>` just won't work here.

## Related Issue

N/A

## Preview Environment Links



<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/4742)
<!-- end placeholder -->
