### PR TITLE
update component-library to 52.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "tar": ">=6.2.1"
   },
   "dependencies": {
-    "@department-of-veterans-affairs/css-library": "^0.24.0",
-    "@department-of-veterans-affairs/component-library": "^52.0.0",
+    "@department-of-veterans-affairs/css-library": "^0.25.0",
+    "@department-of-veterans-affairs/component-library": "^52.1.1",
     "@uswds/uswds": "^3.9.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,22 +9,22 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@department-of-veterans-affairs/component-library@^52.0.0":
-  version "52.0.0"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-52.0.0.tgz#2555fb66ca8a17fdbd695db7350bd90ea134c39a"
-  integrity sha512-Uf6iiPbTJt/5X8Urp8YLJPmrzDmNJGHFsKx8yGFmtHKRMjspBu9q9lf/QrcMXVaVODcjbX3SXlFXLhlzxUh9Ug==
+"@department-of-veterans-affairs/component-library@^52.1.1":
+  version "52.1.1"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-52.1.1.tgz#bdcbb79ba184c251cd76e96bf1062ab808904cba"
+  integrity sha512-B/4U0D/O4Plpqo3KzCOx29qWJD+scShXSqX5NgRCEaAscnclQQ4eg+ahxT0aQKo9QtGsaXo1WSuqTRjIF+fdlw==
   dependencies:
     "@department-of-veterans-affairs/react-components" "28.1.0"
-    "@department-of-veterans-affairs/web-components" "20.0.0"
+    "@department-of-veterans-affairs/web-components" "20.1.1"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/css-library@^0.24.0":
-  version "0.24.0"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/css-library/-/css-library-0.24.0.tgz#2c014c20d37934dbba109475be02c395b1e1265f"
-  integrity sha512-kPCjut7hpR0EvdHYJndIRIFb8dyUoeirj+rd00gGxSi1UbU/jKwLN6CW8kFs/a1sl5qgg4sapvgGky/ukY96WA==
+"@department-of-veterans-affairs/css-library@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/css-library/-/css-library-0.25.0.tgz#948a3d45fff243cb7ff611286b32b8b6d45198fb"
+  integrity sha512-oWBbvCWip6bPMQJeBTwg0JQok++wSfnaljGnn+Ej2P7g5Iw0q0nD2vKbyFhULAfNfSTNGN3rnd0fQ8/gx3y0FQ==
   dependencies:
     "@divriots/style-dictionary-to-figma" "^0.4.0"
     "@uswds/uswds" "^3.9.0"
@@ -41,10 +41,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/web-components@20.0.0":
-  version "20.0.0"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-20.0.0.tgz#7eb3df8d0b2f5479acf54581200b96c1e75911bc"
-  integrity sha512-ibO9z62RQqDrWqKY4sVT8qpja8lLSF7oOzlpFxeYgiP+JR9IaJ6zvuXOnvH0J+KIdrKNaU85g+CPdmIZLN8mCQ==
+"@department-of-veterans-affairs/web-components@20.1.1":
+  version "20.1.1"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-20.1.1.tgz#177f8c126c6d0964437130681cad3759d0737e05"
+  integrity sha512-C0g3995ayrUkKpeR5mKSEnacI4rSZJQAFl8kqXPhYZxJmdkp0h81g6f4HbeVI0r5eQZv2xHgOX38kvwdauXLwA==
   dependencies:
     "@stencil/core" "4.20.0"
     aria-hidden "^1.1.3"
@@ -2648,6 +2648,7 @@ stream-shift@^1.0.0:
   integrity sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2682,6 +2683,7 @@ string_decoder@~1.1.1:
     safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
<!--
  ## How to Title Your PR
  The titles of all PRs appear together on the [What's New](https://design.va.gov/about/whats-new) page. This page is meant to be easily and quickly scanned so a clear, concise explanation is important.

  We recommend PR titles to include updated page or section, start with present tense action verbs (e.g., Fixes, Adds, Improves, Updates), and describe what was updated.

  For example:
  - Checkbox: Adds Storybook examples
  - Experimental Components & Patterns: Improves submission guidance
  - Links: Fixes typos
  - Multiple Responses: Updates usage guidance
-->

## Summary

This PR updates component-library to its latest version.

## Related Issue

_If this PR resolves an open issue, please add the issue number here._

Closes #[Issue_number]

## Preview Environment Links

<!--

  A preview environment is automatically created and updated with every PR (including draft PRs). This allows you to review your changes in a browser just as they will appear after the PR is merged.

  Once you've committed a PR, automated checks will run and then a preview environment will be automatically generated.

  The URL of this preview environment follows this format:

  `https://dev-design.va.gov/[This_PR_number]`

  A minute or two after committing, you will see an entry in the GitHub timeline similar to this:

  > [Your Username] deployed to development [X time] ago - with Github Actions [View Deployment]

  Clicking the **View Deployment** button will open a browser window to preview your changes. Validate your updates are correct BEFORE submitting your PR for review.

  **NOTE:** The preview environment only works for PRs submitted to the official repository. It will not work for forked repositories.

-->

<!--
  Finally, please remove all these PR template comments before submitting. 🚀
-->

<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/4760)
<!-- end placeholder -->
