### PR TITLE
Deprecated components: Move deprecated components to dedicated section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,6 +81,9 @@ collections:
   ia:
     output: true
     permalink: /:collection/:title
+  deprecated:
+    output: true
+    permalink: /deprecated/:title
 
 include:
   - vendor/javascripts/component-library/dist/esm/_commonjsHelpers-8b28c6fa.js

--- a/src/_components/form/index.md
+++ b/src/_components/form/index.md
@@ -12,7 +12,6 @@ sub-pages:
   - sub-page: Date input
   - sub-page: Memorable date
   - sub-page: File input
-  - sub-page: Input message
   - sub-page: Label
   - sub-page: Need help?
   - sub-page: Penalty notice

--- a/src/_deprecated/banner-promo.md
+++ b/src/_deprecated/banner-promo.md
@@ -1,8 +1,7 @@
 ---
 layout: component
 title: Banner - Promo
-permalink: /components/banner/promo
-has-parent: /components/banner/
+status: dont-use-deprecated
 figma-link-web: https://www.figma.com/file/JDFpGLIojfuQwANXScQjqe/VADS-Component-Example-Library?type=design&node-id=1173%3A5043&mode=design&t=vNilCSI60pQBiKkM-1
 intro-text: "A promo banner is fixed content at the bottom of the viewport used for dismissible announcements such as new tools, news, etc."
 research-title: "Promo banners"

--- a/src/_deprecated/input-message.md
+++ b/src/_deprecated/input-message.md
@@ -1,7 +1,5 @@
 ---
 layout: component
-permalink: /components/form/input-message
-has-parent: /components/form/
 title: Input message
 github-title: va-input-message
 intro-text: "Provides helpful, in-context information about an input, either before or immediately after a Veteran interacts with an input (e.g. on a form input that auto-saves)."

--- a/src/_deprecated/notification.md
+++ b/src/_deprecated/notification.md
@@ -1,6 +1,7 @@
 ---
 layout: component
 title: Notification
+status: dont-use-deprecated
 contributor: Angela Agosto, Allison Lu
 intro-text: Provides a visually distinct card in order to surface time-sensitive updates and action items.
 web-component: va-notification

--- a/src/_includes/_site-content-nav.html
+++ b/src/_includes/_site-content-nav.html
@@ -9,7 +9,10 @@
     {% include _side-nav.html section=site.foundation name="foundation" %}
     {% assign collection_name = "Foundation" %}
   {% elsif page.url contains "/components/" %}
-    {% include _side-nav.html section=site.components name="components" %}
+    {% include _site-side-nav-components.html name="components" %}
+    {% assign collection_name = "Components" %}
+  {% elsif page.url contains "/deprecated/" %}
+    {% include _site-side-nav-components.html name="components" %}
     {% assign collection_name = "Components" %}
   {% elsif page.url contains "/patterns/" %}
     {% include _site-side-nav-patterns.html name="patterns" %}

--- a/src/_includes/_site-side-nav-components.html
+++ b/src/_includes/_site-side-nav-components.html
@@ -1,0 +1,98 @@
+<nav class="va-sidebarnav va-sidebarnav--{{include.name}}">
+  <ul class="usa-sidenav-list">
+    {% for p in site.components %}
+      {% if p.index %}
+      <li class="{% if page.index %}active-level{% endif %}">
+        <a class="{% if page.index %}usa-current{% endif %}" href="{{site.baseurl}}{{ p.url | replace: '/index', ''}}">Overview</a>
+      </li>
+      {% endif %}
+    {% endfor %}
+    
+    {% assign sortedPages = site.components | sort: "title", "last" %}
+    {% for p in sortedPages %}
+        
+        {% assign is-current = false %}
+        {% if p.url == page.url or page.url == site.baseurl | append: p.permalink %}
+          {% assign is-current = true %}
+        {% endif %}
+        {% assign open-accordion = false %}
+        {% if p.url == page.url or (page.has-parent == p.permalink) %}
+         {% assign open-accordion = true %}
+        {% endif %}
+        {% if p.layout != "iframe" %}
+          {% unless p.index or p.has-parent %}
+            {% unless p.draft == true and (p.url != page.url) %}
+                {% assign slug = p.title | slugify %}
+                {%- if p.sub-pages -%}
+                  <ul class="usa-accordion">
+                    <li>
+                      <button class="usa-accordion-button" aria-expanded="{%- if open-accordion == true -%}true{%- else -%}false{%- endif -%}" aria-controls="{{p.title | slugify }}">
+                        {{p.title}}
+                        <va-icon icon="add" size="3"></va-icon>
+                        <va-icon icon="remove" size="3"></va-icon>
+                      </button>
+                      <div id="{{ slug }}" class="usa-accordion-content" aria-hidden="{%- if open-accordion == true -%}false{%- else -%}true{%- endif -%}">
+                        <ul class="usa-sidenav-list">
+                          <li {% if is-current == true %}class="active-level"{%- endif -%}>
+                            <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{site.baseurl}}{{ p.url }}">
+                              {% if p.inner-title %}{{ p.inner-title }}{% else %}{{ p.title }}{%- endif -%}
+                              {%- if p.web-component or p.status -%}
+                                {%- include _site-side-nav-status.html components=sortedPages component=p.title -%}
+                              {%- endif -%}
+                            </a>
+                          </li>
+                          {% for item in p.sub-pages %}
+                            {% assign link = page.url %}
+                            {% assign slug = item.sub-page | slugify %}
+                            {% if link contains slug %}
+                              {% assign is-current = true %}
+                            {% else %}
+                              {% assign is-current = false %}
+                            {% endif %}
+                          <li>
+                            <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{site.baseurl}}{{p.permalink }}{{ item.sub-page | slugify }}">
+                              {{ item.sub-page }}
+                              {%- include _site-side-nav-status.html components=sortedPages component=item.sub-page parent=p.title -%}
+                            </a>
+                          </li>
+                          {% endfor %}
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                  {%- else -%}
+                  <li {% if is-current == true %}class="active-level"{%- endif -%}>
+                    <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{site.baseurl}}{{ p.url }}">
+                      {{p.title}}
+                      {%- include _site-side-nav-status.html components=sortedPages component=p.title -%}
+                    </a>
+                  </li>
+                {%- endif -%}
+            {% endunless %}
+          {% endunless %}
+        {% endif %}
+    {% endfor %}
+  </ul>
+    
+  {% comment %}Deprecated Components Section{% endcomment %}
+  <h3 class="va-sidebarnav__sub-section vads-u-margin-top--0">Deprecated</h3>
+  <ul class="usa-sidenav-list">
+    {% assign sortedDeprecated = site.deprecated | sort: "title", "last" %}
+    {% for p in sortedDeprecated %}
+      {% assign is-current = false %}
+      {% if p.url == page.url %}
+        {% assign is-current = true %}
+      {% endif %}
+      {% unless p.index %}
+        <li {% if is-current == true %}class="active-level"{%- endif -%}>
+          <a class="{% if is-current == true %}usa-current{%- endif -%}" href="{{site.baseurl}}{{ p.url }}">
+            {{p.title}}
+            {%- if p.status -%}
+              {%- include _site-side-nav-status.html pattern-status=p.status -%}
+            {%- endif -%}
+          </a>
+        </li>
+      {% endunless %}
+    {% endfor %}
+  </ul>
+</nav>


### PR DESCRIPTION
## Summary
We have a deprecated section in Storybook and for Patterns but not for components. This PR creates a deprecated section in the components section. Deprecated components now appear only in a dedicated 'Deprecated' section at the bottom of the components navigation with proper status indicators.

- Create new _deprecated collection for deprecated components
- Move Banner - Promo, Input message, and Notification to _deprecated folder
- Add deprecated section to components navigation with status icons
- Update _site-content-nav.html to show components navigation for deprecated URLs
- Remove deprecated components from main navigation and form sub-pages
- Add zero top margin styling to deprecated section for compact layout
- Fix left indentation by restructuring deprecated section outside main list

## Preview Environment Links

<!--

  A preview environment is automatically created and updated with every PR (including draft PRs). This allows you to review your changes in a browser just as they will appear after the PR is merged.

  Once you've committed a PR, automated checks will run and then a preview environment will be automatically generated.

  The URL of this preview environment follows this format:

  `https://dev-design.va.gov/[This_PR_number]`

  A minute or two after committing, you will see an entry in the GitHub timeline similar to this:

  > [Your Username] deployed to development [X time] ago - with Github Actions [View Deployment]

  Clicking the **View Deployment** button will open a browser window to preview your changes. Validate your updates are correct BEFORE submitting your PR for review.

  **NOTE:** The preview environment only works for PRs submitted to the official repository. It will not work for forked repositories.

-->

<!--
  Finally, please remove all these PR template comments before submitting. 🚀
-->

<!-- start placeholder for CI job -->

This will be updated automatically 🪄✨

<!-- end placeholder -->
