### PR TITLE
Enable manual deployment workflow trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual deployment'
+        required: false
+        default: 'Manual deployment triggered'
 
 jobs:
   deploy:


### PR DESCRIPTION
Add workflow_dispatch to the Deploy site workflow to allow manual triggering from the GitHub UI.

## Changes
- Added `workflow_dispatch` trigger to the Deploy site workflow
- Added optional 'reason' input parameter for better tracking and documentation

## How to use
Once merged, you can trigger deployments manually by:
1. Going to Actions > Deploy site workflow
2. Clicking 'Run workflow' button
3. Optionally entering a reason for the deployment
4. Selecting the main branch and clicking 'Run workflow'

This provides a way to deploy the current site without needing to push new commits to main.<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/5037)
<!-- end placeholder -->