### PR TITLE
Refactor projects field in accessibility issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/5_Accessibility-issue.yml
+++ b/.github/ISSUE_TEMPLATE/5_Accessibility-issue.yml
@@ -3,8 +3,7 @@ description: "Use this template to report accessibility defects for VA Design Sy
 labels: ["accessibility", "needs-triage", "platform-design-system-team"]
 title: "[accessibility-defect-X]: Description of bug "
 type: bug
-projects:
-  - https://github.com/orgs/department-of-veterans-affairs/projects/1643/
+projects: ["department-of-veterans-affairs/1643"]
   
 body:
   - type: markdown


### PR DESCRIPTION
## Summary

Updated the projects field format in the accessibility issue template. Sorry for all these PRs. I can't test this until it's merged.

## Related Issue


## Preview Environment Links


<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/5066)
<!-- end placeholder -->
