### PR TITLE
BUG: Remove references to Promo banner component in side nav

### DIFF
--- a/src/_components/banner/index.md
+++ b/src/_components/banner/index.md
@@ -9,7 +9,6 @@ mobile-app: false
 sub-pages:
   - sub-page: Maintenance
   - sub-page: Official Gov
-  - sub-page: Promo
 anchors:
   - anchor: Examples
   - anchor: Usage
@@ -54,7 +53,6 @@ anchors:
 
 * **User feedback.** User feedback is provided via [feedback messages]({{ site.baseurl }}/content-style-guide/error-messages/feedback) that respond to an action a user has taken and to draw their attention to something that they need to correct or to confirm successful completion of a task. These messages are handled by the [Alert]({{ site.baseurl }}/components/alert) component.
 * **In-application system status, engagement, and access messages.** All of the messages in our [messages dictionary]({{ site.baseurl }}/content-style-guide/error-messages) are handled by the [Alert]({{ site.baseurl }}/components/alert) component. For application-level maintenance, review the [downtime notifications guidance](https://depo-platform-documentation.scrollhelp.site/developer-docs/downtime-notifications).
-* **News, promotion, new tools, etc.** Promotional items or general news that may be relevant to a broad audience of Veterans is better placed in the [Banner - Promo]({{ site.baseurl }}/components/banner/promo) component. To ensure that customers always know they can find critical service information in this area, don’t use Banner for general press, outreach, or administrative messages.
 * **System maintenance.** Before and during maintenance there are [specific system status messages]({{ site.baseurl }}/content-style-guide/error-messages/system) that we use to communicate the maintenance window to users which is handled by the [Banner - Maintenance]({{ site.baseurl }}/components/banner/maintenance) component. 
 * **Helping a Veteran maintain their health.** Another category of messages are broadly related to helping Veterans manage their health. These messages should be managed with a combination of Content Management System (CMS) components as follows:
   * Call center/secure messaging promotion: Story with spotlight.


### PR DESCRIPTION
 ## Summary

The 'Promo' banner was still showing up in the Banner side navigation and there were also some references to the Promo banner on the banner index page that were removed. 

Deleted the 'Promo' sub-page and related documentation about the Banner - Promo component from the banner index markdown file.

## Preview Environment Links

<!--

  A preview environment is automatically created and updated with every PR (including draft PRs). This allows you to review your changes in a browser just as they will appear after the PR is merged.

  Once you've committed a PR, automated checks will run and then a preview environment will be automatically generated.

  The URL of this preview environment follows this format:

  `https://dev-design.va.gov/[This_PR_number]`

  A minute or two after committing, you will see an entry in the GitHub timeline similar to this:

  > [Your Username] deployed to development [X time] ago - with Github Actions [View Deployment]

  Clicking the **View Deployment** button will open a browser window to preview your changes. Validate your updates are correct BEFORE submitting your PR for review.

  **NOTE:** The preview environment only works for PRs submitted to the official repository. It will not work for forked repositories.

-->

<!--
  Finally, please remove all these PR template comments before submitting. 🚀
-->

<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/5174)
<!-- end placeholder -->
