### PR TITLE
Add comprehensive PII/PHI privacy guidance page

### DIFF
--- a/src/_content-style-guide/privacy-and-pii-phi.md
+++ b/src/_content-style-guide/privacy-and-pii-phi.md
@@ -39,7 +39,7 @@ Some information can be used indirectly to identify an individual, such as by co
 - Date of birth, race, or religion
 - Employment information
 - Medical information such as health vitals or conditions, services or treatments received, medications, or service payment information
-  - Prescribed medication name, labs and tests for specific injuries or illnesses, AVS that specifies reason for visit, message content, specific appointment types, etc.
+  - Prescribed medication name, labs and tests for specific injuries or illnesses, after-visit summary (AVS) that specifies reason for visit, message content, specific appointment types, etc.
 - Education information
 - Financial information
 


### PR DESCRIPTION
## Summary
Adds a dedicated reference page for PII/PHI privacy guidance in the Content Style Guide.

## Related Issue
Closes #3632

## Background
Issue #3632 requested updates to components for PII/PHI guidance. The Content & IA team added privacy guidance sections to individual components and content style guide pages (title-tags, page-titles, alt-text, breadcrumbs, search-input, url-standards).

However, the comprehensive "Supporting Information" reference document (defining what PII/PHI is, examples of direct/indirect identifiers, UI/UX placement guidance) was not added as a standalone page. This PR adds that content.

## What's Added
A new page at `/content-style-guide/privacy-and-pii-phi` containing:

### Definitions
- What is PII (Personally Identifiable Information)
- What is PHI (Protected Health Information)

### Examples
- **Direct identifiers:** Name, SSN, ITIN, driver's license, passport, address, phone, email, biometrics, ICN, EDIPI, IP address
- **Indirect identifiers:** DOB, race, religion, employment, medical info, education, financial info
- **Ambiguous vs. specific:** Do/Don't examples ("Blood pressure" OK vs "Blood pressure 132/78" not OK)

### UI/UX Placement Guidance
- Where PII/PHI must **never** appear (cookies, URLs, parameters, title tags, breadcrumbs)
- Where it may appear with caution (link labels, form fields, open text)

### Analytics Guidance
- Don't add tracking for elements containing PII/PHI

### Cross-references
- Links to all related component-specific privacy guidance

## Review Request
@mnorthuis - This completes the supporting reference content from the original Word document. Please review to confirm this matches what was intended.

## Testing
- [x] Jekyll build succeeds
- [x] Page renders correctly<!-- start placeholder for CI job -->
[Open Preview Environment](https://dev-design.va.gov/5528)
<!-- end placeholder -->