### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Veteran Affairs Design System
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/department-of-veterans-affairs/vets-design-system-documentation)
 
 The Veteran Affairs Design System (VADS) exists to provide design guidelines and code, enabling teams to rapidly create trustworthy, accessible, and consistent digital services on the VA.gov platform.
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/department-of-veterans-affairs/vets-design-system-documentation) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.